### PR TITLE
Calibrate the scale

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 runner = "probe-rs run --no-location"
 
 [env]
-DEFMT_LOG             = "debug"           # Use "off" to disbale defmt logging
+DEFMT_LOG             = "info"            # Use "off" to disbale defmt logging
 DEVICE_ID             = "42"
 DEVICE_NAME           = "Progressor_7125"
 DEVICE_VERSION_NUMBER = "1.2.3.4"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 runner = "probe-rs run --no-location"
 
 [env]
-DEFMT_LOG             = "info"            # Use "off" to disbale defmt logging
+DEFMT_LOG             = "debug"           # Use "off" to disbale defmt logging
 DEVICE_ID             = "42"
 DEVICE_NAME           = "Progressor_7125"
 DEVICE_VERSION_NUMBER = "1.2.3.4"

--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -11,9 +11,9 @@ use esp_hal::{
 };
 
 /// Obtained calibration factor
-const CALIBRATION_FACTOR: f32 = 1.3153;
+const CALIBRATION_FACTOR: f32 = 1.3145;
 /// Obtained calibration offset
-const CALIBRATION_OFFSET: f32 = -3.867;
+const CALIBRATION_OFFSET: f32 = -3.8790;
 
 /// The HX711 has different amplifier gain settings.
 /// The choice of gain settings is controlled by writing a fixed number of

--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -79,7 +79,7 @@ impl<'d> Hx711<'d> {
     }
 
     /// Returns true if the load cell amplifier has a value ready to be read.
-    pub fn is_ready(&mut self) -> bool {
+    fn is_ready(&mut self) -> bool {
         self.data.is_low()
     }
 
@@ -155,7 +155,7 @@ impl<'d> Hx711<'d> {
     }
 
     /// Reads a raw value from the HX711, subtracting the tare offset.
-    pub fn read(&mut self) -> Option<i32> {
+    fn read(&mut self) -> Option<i32> {
         if !self.is_ready() {
             return None;
         }

--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -10,6 +10,11 @@ use esp_hal::{
     gpio::{Input, Output},
 };
 
+/// Obtained calibration factor
+const CALIBRATION_FACTOR: f32 = 1.322;
+/// Obtained calibration offset
+const CALIBRATION_OFFSET: f32 = -3.89;
+
 /// The HX711 has different amplifier gain settings.
 /// The choice of gain settings is controlled by writing a fixed number of
 /// extra pulses after a read.
@@ -33,6 +38,12 @@ const HX711_DELAY_TIME_US: u32 = 1;
 /// The delay time in microseconds for the HX711 tare function.
 const HX711_TARE_SLEEP_TIME_US: u32 = 10_000;
 
+/// Calibration values
+struct Calibration {
+    offset: f32,
+    factor: f32,
+}
+
 /// A driver for the HX711 24-bit ADC.
 pub struct Hx711<'d> {
     /// Data pin
@@ -44,9 +55,9 @@ pub struct Hx711<'d> {
     /// Gain mode
     gain_mode: GainMode,
     /// Tare value
-    offset: i32,
-    /// Calibration value
-    scale: f32,
+    tare_value: i32,
+    /// Calibration
+    calibration: Calibration,
 }
 
 impl<'d> Hx711<'d> {
@@ -59,8 +70,11 @@ impl<'d> Hx711<'d> {
             clock,
             delay,
             gain_mode: GainMode::A64,
-            offset: 0,
-            scale: 1.0,
+            tare_value: 0,
+            calibration: Calibration {
+                offset: CALIBRATION_OFFSET,
+                factor: CALIBRATION_FACTOR,
+            },
         }
     }
 
@@ -95,16 +109,6 @@ impl<'d> Hx711<'d> {
     /// Sets the gain mode for the next reading.
     pub fn set_gain_mode(&mut self, gain_mode: GainMode) {
         self.gain_mode = gain_mode;
-    }
-
-    /// Sets the offset value.
-    pub fn set_offset(&mut self, offset: i32) {
-        self.offset = offset;
-    }
-
-    /// Sets the calibration scale value.
-    pub fn set_scale(&mut self, scale: f32) {
-        self.scale = scale;
     }
 
     /// Reads 24 bits from the HX711 within a critical section.
@@ -147,7 +151,7 @@ impl<'d> Hx711<'d> {
             self.delay.delay_us(HX711_TARE_SLEEP_TIME_US);
         }
 
-        self.offset = total as i32;
+        self.tare_value = total as i32;
     }
 
     /// Reads a raw value from the HX711, subtracting the tare offset.
@@ -156,12 +160,13 @@ impl<'d> Hx711<'d> {
             return None;
         }
 
-        Some(self.read_raw() - self.offset)
+        Some(self.read_raw() - self.tare_value)
     }
 
     /// Reads a scaled value from the HX711.
     pub fn read_scaled(&mut self) -> Option<f32> {
-        self.read().map(|raw| raw as f32 * self.scale)
+        self.read()
+            .map(|raw| raw as f32 * self.calibration.factor - self.calibration.offset)
     }
 
     /// Get the average of 20 readings in kgs.

--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -163,8 +163,8 @@ impl<'d> Hx711<'d> {
         Some(self.read_raw() - self.tare_value)
     }
 
-    /// Reads a scaled value from the HX711.
-    pub fn read_scaled(&mut self) -> Option<f32> {
+    /// Reads a calibrated value from the HX711.
+    fn read_calibrated(&mut self) -> Option<f32> {
         self.read()
             .map(|raw| raw as f32 * self.calibration.factor - self.calibration.offset)
     }
@@ -176,7 +176,7 @@ impl<'d> Hx711<'d> {
 
         let mut weight = 0.0;
         for _ in 0..20 {
-            if let Some(x) = self.read_scaled() {
+            if let Some(x) = self.read_calibrated() {
                 // Don't take absolute value - keep the sign
                 weight += x;
             }

--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -11,9 +11,9 @@ use esp_hal::{
 };
 
 /// Obtained calibration factor
-const CALIBRATION_FACTOR: f32 = 1.322;
+const CALIBRATION_FACTOR: f32 = 1.3153;
 /// Obtained calibration offset
-const CALIBRATION_OFFSET: f32 = -3.89;
+const CALIBRATION_OFFSET: f32 = -3.867;
 
 /// The HX711 has different amplifier gain settings.
 /// The choice of gain settings is controlled by writing a fixed number of


### PR DESCRIPTION
In order to calibrate the scale:
1. I commented the taring calls of the code
2. Set the calibration factor to `1.0` and calibration offset to `0.0`
3. Recorded the device measurement with no weights attached to it (our zero point):  **`-2.94 kg`**
4. Recorded the device measurement with 81 kg attached to it (I don't expect to pull more than this, so it's virtually our end of scale): **`58.34 kg`**
5. Calculate the offset with those results:
    ```
    factor = (81 - 0) / (58.34 - (-2.94)) = 1.322
    offset = 0 − (1.322 ×−2.94) = 3.887
    ```
   - After doing some research I noticed that the lifting pin was not 1kg as I estimated (I used 80 kgs + lifting pin), it's more like [600gr](https://latticetraining.com/product/lifting-pin/#tab-description), so I updated the calibration to: 
    ```
    factor = (80.6 - 0) / (58.34 - (-2.94)) = 1.3153
    offset = 0 − (1.3153 × −2.94) = 3.867
    ```
    
 Extra update: Measured the points for some seconds and did the average value instead of a single measure, the new zero point is `-2.95094`, new 80.60kg is `58.365` so here are the new constant:
```
factor = (80.6 - 0) / (58.365 - (-2.95094)) = 1.3145
offset = 0 − (1.31450 × −2.95094) = 3.8790
```

Here is a diff of the modified code to calculate the values (described in points 1. and 2.):
```diff
❯ git diff
diff --git a/src/hx711.rs b/src/hx711.rs
index 45716bd..4a01c64 100644
--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -11,9 +11,9 @@ use esp_hal::{
 };
 
 /// Obtained calibration factor
-const CALIBRATION_FACTOR: f32 = 1.3153;
+const CALIBRATION_FACTOR: f32 = 1.0;
 /// Obtained calibration offset
-const CALIBRATION_OFFSET: f32 = -3.867;
+const CALIBRATION_OFFSET: f32 = 0.0;
 
diff --git a/src/main.rs b/src/main.rs
index 8b626f3..1f69423 100644
--- a/src/main.rs
+++ b/src/main.rs
@@ -322,7 +322,7 @@ async fn measurement_task(
             continue;
         }
         if status == MeasurementTaskStatus::Tare {
-            load_cell.tare(16).await;
+            // load_cell.tare(16).await;

@@ -331,7 +331,7 @@ async fn measurement_task(
         }
 
         let weigth = if status == MeasurementTaskStatus::SoftTare {
-            load_cell.tare(16).await;
+            // load_cell.tare(16).await;

@@ -345,7 +345,7 @@ async fn measurement_task(
 
         let measurement = ResponseCode::WeigthtMeasurement(weigth, timestamp);
-        debug!("Sending measurement: {:?}", measurement);
+        error!("Sending measurement: {:?}", measurement);
```