### PR TITLE
Improve sampling freq

### DIFF
--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -11,9 +11,9 @@ use esp_hal::{
 };
 
 /// Obtained calibration factor
-const CALIBRATION_FACTOR: f32 = 1.0;
+const CALIBRATION_FACTOR: f32 = 0.06672;
 /// Obtained calibration offset
-const CALIBRATION_OFFSET: f32 = 0.0;
+const CALIBRATION_OFFSET: f32 = 52.8916;
 
 /// The absolute minimum readings. A smaller value should be clamped.
 const HX711_MINIMUM: i32 = -(2i32.saturating_pow(24 - 1));

--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -142,13 +142,13 @@ impl<'d> Hx711<'d> {
         const TARING_SAMPLES: usize = 16;
         let mut total: f32 = 0.0;
 
-        for n in 1..=TARING_SAMPLES {
+        for _ in 0..=TARING_SAMPLES {
             self.wait_for_ready().await;
-            let current = self.read_raw() as f32;
-            total += (current - total) / n as f32;
+            total += self.read_raw() as f32;
             self.delay.delay_us(HX711_TARE_SLEEP_TIME_US);
         }
-        self.tare_value = total as i32;
+        let average = total / TARING_SAMPLES as f32;
+        self.tare_value = average as i32;
     }
 
     /// Reads a calibrated value, in kg.

--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -11,9 +11,18 @@ use esp_hal::{
 };
 
 /// Obtained calibration factor
-const CALIBRATION_FACTOR: f32 = 1.3145;
+const CALIBRATION_FACTOR: f32 = 1.0;
 /// Obtained calibration offset
-const CALIBRATION_OFFSET: f32 = -3.8790;
+const CALIBRATION_OFFSET: f32 = 0.0;
+
+/// The absolute minimum readings. A smaller value should be clamped.
+const HX711_MINIMUM: i32 = -(2i32.saturating_pow(24 - 1));
+/// The absolute maximum readings. A greater value should be clamped.
+const HX711_MAXIMUM: i32 = 2i32.saturating_pow(24 - 1) - 1;
+/// The default delay time in microseconds for the HX711.
+const HX711_DELAY_TIME_US: u32 = 1;
+/// The delay time in microseconds for the HX711 tare function.
+const HX711_TARE_SLEEP_TIME_US: u32 = 10_000;
 
 /// The HX711 has different amplifier gain settings.
 /// The choice of gain settings is controlled by writing a fixed number of
@@ -28,15 +37,6 @@ pub enum GainMode {
     /// Amplification gain of 64 on channel A.
     A64 = 3,
 }
-
-/// The absolute minimum readings. A smaller value should be clamped.
-const HX711_MINIMUM: i32 = -(2i32.saturating_pow(24 - 1));
-/// The absolute maximum readings. A greater value should be clamped.
-const HX711_MAXIMUM: i32 = 2i32.saturating_pow(24 - 1) - 1;
-/// The default delay time in microseconds for the HX711.
-const HX711_DELAY_TIME_US: u32 = 1;
-/// The delay time in microseconds for the HX711 tare function.
-const HX711_TARE_SLEEP_TIME_US: u32 = 10_000;
 
 /// Calibration values
 struct Calibration {
@@ -93,12 +93,14 @@ impl<'d> Hx711<'d> {
 
     /// Toggles the clock pin to prepare for the next gain mode.
     fn send_gain_pulses(&mut self) {
-        for _ in 0..(self.gain_mode as u8) {
-            self.clock.set_high();
-            self.delay.delay_us(HX711_DELAY_TIME_US);
-            self.clock.set_low();
-            self.delay.delay_us(HX711_DELAY_TIME_US);
-        }
+        critical_section::with(|_| {
+            for _ in 0..(self.gain_mode as u8) {
+                self.clock.set_high();
+                self.delay.delay_us(HX711_DELAY_TIME_US);
+                self.clock.set_low();
+                self.delay.delay_us(HX711_DELAY_TIME_US);
+            }
+        });
     }
 
     /// Sets the gain mode for the next reading.
@@ -136,16 +138,16 @@ impl<'d> Hx711<'d> {
     }
 
     /// Tares the sensor by measuring the average of `num_samples` readings.
-    pub async fn tare(&mut self, num_samples: usize) {
+    pub async fn tare(&mut self) {
+        const TARING_SAMPLES: usize = 16;
         let mut total: f32 = 0.0;
 
-        for n in 1..=num_samples {
+        for n in 1..=TARING_SAMPLES {
             self.wait_for_ready().await;
             let current = self.read_raw() as f32;
             total += (current - total) / n as f32;
             self.delay.delay_us(HX711_TARE_SLEEP_TIME_US);
         }
-
         self.tare_value = total as i32;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,8 +330,6 @@ async fn measurement_task(
             load_cell.tare(16).await;
             critical_section::with(|cs| {
                 *MEASUREMENT_TASK_STATUS.borrow_ref_mut(cs) = MeasurementTaskStatus::Enabled;
-            });
-            critical_section::with(|cs| {
                 *DEVICE_TARED.borrow_ref_mut(cs) = true;
             });
             0.0

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use bleps::{
 };
 use bytemuck::bytes_of;
 use critical_section::Mutex;
-use defmt::{debug, error, info, trace};
+use defmt::{debug, error, info};
 use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_sync::channel::Channel;
@@ -294,7 +294,7 @@ async fn bt_task(connector: BleConnector<'static>, channel: &'static DataPointCh
 
         let mut notifier = || async {
             let data_point = channel.receive().await;
-            trace!("Notifying data point: {:?}", data_point);
+            debug!("Notifying data point: {:?}", data_point);
             let data = bytes_of(&data_point);
             NotificationData::new(data_point_handle, data)
         };
@@ -314,7 +314,7 @@ async fn measurement_task(
     loop {
         let status = critical_section::with(|cs| *MEASUREMENT_TASK_STATUS.borrow_ref(cs));
         if status == MeasurementTaskStatus::Disabled {
-            Timer::after(Duration::from_millis(13)).await;
+            Timer::after(Duration::from_millis(10)).await;
             continue;
         }
         if status == MeasurementTaskStatus::Tare {
@@ -322,7 +322,7 @@ async fn measurement_task(
             critical_section::with(|cs| {
                 *DEVICE_TARED.borrow_ref_mut(cs) = true;
             });
-            Timer::after(Duration::from_millis(13)).await;
+            Timer::after(Duration::from_millis(10)).await;
             continue;
         }
 
@@ -336,7 +336,7 @@ async fn measurement_task(
             });
             0.0
         } else {
-            load_cell.get_measurement().await
+            load_cell.read_calibrated().await
         };
 
         let timestamp = (time::Instant::now().duration_since_epoch()).as_micros() as u32;
@@ -344,9 +344,5 @@ async fn measurement_task(
         debug!("Sending measurement: {:?}", measurement);
         let data_point = DataPoint::new(measurement);
         channel.send(data_point).await;
-        // On average, measurements take 300 microseconds (0.3ms)
-        // Tindeq can receive samples at 80Hz (12.5ms)
-        // So, we can sleep for 10ms
-        Timer::after(Duration::from_millis(10)).await;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,7 +318,7 @@ async fn measurement_task(
             continue;
         }
         if status == MeasurementTaskStatus::Tare {
-            load_cell.tare(16).await;
+            load_cell.tare().await;
             critical_section::with(|cs| {
                 *DEVICE_TARED.borrow_ref_mut(cs) = true;
             });
@@ -327,7 +327,7 @@ async fn measurement_task(
         }
 
         let weight = if status == MeasurementTaskStatus::SoftTare {
-            load_cell.tare(16).await;
+            load_cell.tare().await;
             critical_section::with(|cs| {
                 *MEASUREMENT_TASK_STATUS.borrow_ref_mut(cs) = MeasurementTaskStatus::Enabled;
                 *DEVICE_TARED.borrow_ref_mut(cs) = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,7 +326,7 @@ async fn measurement_task(
             continue;
         }
 
-        let weigth = if status == MeasurementTaskStatus::SoftTare {
+        let weight = if status == MeasurementTaskStatus::SoftTare {
             load_cell.tare(16).await;
             critical_section::with(|cs| {
                 *MEASUREMENT_TASK_STATUS.borrow_ref_mut(cs) = MeasurementTaskStatus::Enabled;
@@ -338,7 +338,7 @@ async fn measurement_task(
         };
 
         let timestamp = (time::Instant::now().duration_since_epoch()).as_micros() as u32;
-        let measurement = ResponseCode::WeigthtMeasurement(weigth, timestamp);
+        let measurement = ResponseCode::WeigthtMeasurement(weight, timestamp);
         debug!("Sending measurement: {:?}", measurement);
         let data_point = DataPoint::new(measurement);
         channel.send(data_point).await;


### PR DESCRIPTION
At the moment, my HX711 `RATE` pin is connected to `GND`, which means the sampling frequency is 10Hz, and after this changes that freq is achieved. Tested it using the nrfConnect app, subscribing to the data service, saving the log and checking the timestamps, we can see that in a second, 10 samples were received:
```
17:02:04.043	Notification received from 7e4e1702-1ea6-40c9-9dcc-13d34ffead57, value: (0x) 01-08-74-41-93-C2-76-BB-C7-01-00-00-00-00
17:02:04.143	Notification received from 7e4e1702-1ea6-40c9-9dcc-13d34ffead57, value: (0x) 01-08-EF-50-93-C2-59-4F-C9-01-00-00-00-00
17:02:04.243	Notification received from 7e4e1702-1ea6-40c9-9dcc-13d34ffead57, value: (0x) 01-08-2E-48-93-C2-38-E3-CA-01-00-00-00-00
17:02:04.343	Notification received from 7e4e1702-1ea6-40c9-9dcc-13d34ffead57, value: (0x) 01-08-6F-3F-93-C2-1B-77-CC-01-00-00-00-00
17:02:04.447	Notification received from 7e4e1702-1ea6-40c9-9dcc-13d34ffead57, value: (0x) 01-08-C3-3E-93-C2-08-0B-CE-01-00-00-00-00
17:02:04.599	Notification received from 7e4e1702-1ea6-40c9-9dcc-13d34ffead57, value: (0x) 01-08-7D-45-93-C2-E7-9E-CF-01-00-00-00-00
17:02:04.647	Notification received from 7e4e1702-1ea6-40c9-9dcc-13d34ffead57, value: (0x) 01-08-F9-31-93-C2-CC-32-D1-01-00-00-00-00
17:02:04.743	Notification received from 7e4e1702-1ea6-40c9-9dcc-13d34ffead57, value: (0x) 01-08-BD-3C-93-C2-34-C8-D2-01-00-00-00-00
17:02:04.843	Notification received from 7e4e1702-1ea6-40c9-9dcc-13d34ffead57, value: (0x) 01-08-64-3B-93-C2-A8-5A-D4-01-00-00-00-00
17:02:04.943	Notification received from 7e4e1702-1ea6-40c9-9dcc-13d34ffead57, value: (0x) 01-08-C3-3E-93-C2-85-EE-D5-01-00-00-00-00
```


