### PR TITLE
Update sampling frequency

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,10 @@ DEVICE_ID             = "42"
 DEVICE_NAME           = "Progressor_7125"
 DEVICE_VERSION_NUMBER = "1.2.3.4"
 
+# esp-wifi config
+# This will allow sending data points up to 100 Hz
+ESP_WIFI_CONFIG_TICK_RATE_HZ = "160"
+
 [build]
 rustflags = [
   "-C",

--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -160,6 +160,7 @@ impl<'d> Hx711<'d> {
         self.wait_for_ready().await;
         let raw_value = self.read_raw() - self.tare_value;
         let calibrated_value = raw_value as f32 * self.calibration.factor - self.calibration.offset;
+        // Convert to kg
         calibrated_value / 1000.0
     }
 }

--- a/src/progressor.rs
+++ b/src/progressor.rs
@@ -9,7 +9,7 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, channel::Channel};
 use esp_hal::time;
 
 /// Size of the channel used to send data points
-const DATA_POINT_COMMAND_CHANNEL_SIZE: usize = 50;
+const DATA_POINT_COMMAND_CHANNEL_SIZE: usize = 80;
 /// Channel used to send data points
 pub type DataPointChannel = Channel<NoopRawMutex, DataPoint, DATA_POINT_COMMAND_CHANNEL_SIZE>;
 


### PR DESCRIPTION
Updated the HX711 `RATE` pin of my prototypes to sample at 80Hz, that required updating the `ESP_WIFI_CONFIG_TICK_RATE_HZ` config value, otherwise, I could only sample at 50Hz.

I also updated the `DATA_POINT_COMMAND_CHANNEL_SIZE` 