### PR TITLE
Support multi-point calibration, store points, and log points on GetCalibration

### DIFF
--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -164,7 +164,7 @@ impl<'d> Hx711<'d> {
             return Err(Hx711Error::InvalidCalibration);
         }
 
-        debug!("Updating calibration factor: {}", factor);
+        info!("Updating calibration factor: {}", factor);
         self.write_to_flash(factor)?;
 
         self.calibration_factor = factor;
@@ -373,5 +373,4 @@ impl<'d> Hx711<'d> {
             }
         }
     }
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,9 +40,9 @@ use crate::{
         DataPoint,
         DataPointChannel,
         DeviceState,
-        MAX_CALIBRATION_POINTS,
         MeasurementTaskStatus,
         ResponseCode,
+        MAX_CALIBRATION_POINTS,
     },
 };
 
@@ -335,8 +335,7 @@ async fn measurement_task(
                     }
 
                     if state.calibration_point_count >= 2 {
-                        let points =
-                            &state.calibration_points[..state.calibration_point_count];
+                        let points = &state.calibration_points[..state.calibration_point_count];
                         if !load_cell.apply_multi_point_calibration(points) {
                             error!(
                                 "Failed to apply calibration points: {:?}",
@@ -375,7 +374,7 @@ async fn measurement_task(
                             &state.calibration_points[..state.calibration_point_count]
                         );
                     } else {
-                        info!("Calibration points: []");
+                        info!("No calibration points found (Calibration points are lost on device power off)");
                     }
                     state.measurement_status = MeasurementTaskStatus::Disabled;
                 });

--- a/src/progressor.rs
+++ b/src/progressor.rs
@@ -3,7 +3,7 @@
 /// See [Tindeq API documentation] for more information
 ///
 /// [Tindeq API documentation]: https://tindeq.com/progressor_api/
-use defmt::{debug, error, info, trace, Format};
+use defmt::{error, info, trace, Format};
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, channel::Channel};
 use esp_hal::time;
 use trouble_host::types::gatt_traits::{AsGatt, FromGatt, FromGattError};
@@ -19,7 +19,7 @@ pub const MAX_PAYLOAD_SIZE: usize = 10;
 /// Number of bytes in the device ID
 const DEVICE_ID_SIZE: usize = 6;
 /// Maximum number of calibration points to store
-pub const MAX_CALIBRATION_POINTS: usize = 8;
+pub const MAX_CALIBRATION_POINTS: usize = 20;
 
 /// Calibration point storing raw value and known weight
 pub type CalibrationPoint = (f32, f32);
@@ -221,7 +221,7 @@ impl ControlOpCode {
                 };
 
                 device_state.calibrate(weight);
-                debug!(
+                info!(
                     "Received AddCalibrationPoint command with measurement: {}",
                     weight
                 );


### PR DESCRIPTION
### Motivation
- Replace the previous two-point-only calibration with a flexible multi-point workflow to improve calibration accuracy and preserve the legacy two-point API.
- Make calibration state inspectable by printing all stored calibration points when `GetCalibration` is requested.

### Description
- Add `MAX_CALIBRATION_POINTS` and `CalibrationPoint` (`(f32, f32)`) in `progressor.rs` and change `DeviceState` to store `calibration_points: [CalibrationPoint; MAX_CALIBRATION_POINTS]` plus a `calibration_point_count` for tracking.
- Update `main.rs` measurement flow to append collected calibration points, ignore new points when the buffer is full with a `warn!`, apply calibration once `calibration_point_count >= 2`, reset `calibration_point_count` on `DefaultCalibration`, and log stored points on `GetCalibration` using `info!`.
- Implement `Hx711::apply_multi_point_calibration(&[(f32,f32)])` in `hx711.rs` to compute a best-fit scale from deltas relative to a baseline point and validate inputs, and add `apply_two_point_calibration` as a thin wrapper that reuses the multi-point implementation.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69874d2820708332a742b1a5f3ca296b)