### PR TITLE
 Fix BLE advertising and harden sensor handling                                                                   

### DIFF
--- a/src/ble.rs
+++ b/src/ble.rs
@@ -4,10 +4,7 @@
 /// It includes the BLE advertising data, the GATT server, and the BLE connection.
 use arrayvec::ArrayVec;
 use defmt::{debug, info};
-use trouble_host::{
-    advertise::{AD_FLAG_LE_LIMITED_DISCOVERABLE, SIMUL_LE_BR_HOST},
-    prelude::*,
-};
+use trouble_host::prelude::*;
 
 use crate::progressor::{DataPoint, MAX_PAYLOAD_SIZE};
 
@@ -18,26 +15,32 @@ pub const L2CAP_CHANNELS_MAX: usize = 2; // Signal + att
 /// Size of L2CAP packets
 pub const L2CAP_MTU: usize = 255;
 
-/// Progressor BLE Scan Response
+/// BLE AD type for a complete list of 128-bit service UUIDs.
+const AD_TYPE_COMPLETE_128BIT_SERVICE_UUIDS: u8 = 0x07;
+/// Progressor service UUID encoded in BLE little-endian order.
+const PROGRESSOR_SERVICE_UUID_LE: [u8; 16] = [
+    0x57, 0xad, 0xfe, 0x4f, 0xd3, 0x13, 0xcc, 0x9d, 0xc9, 0x40, 0xa6, 0x1e, 0x01, 0x17, 0x4e, 0x7e,
+];
+/// Progressor BLE Scan Response.
 const SCAN_RESPONSE_DATA: &[u8] = &[
-    AD_FLAG_LE_LIMITED_DISCOVERABLE | SIMUL_LE_BR_HOST,
-    7_u8, // BLE_GAP_AD_TYPE_128BIT_SERVICE_UUID_COMPLETE
-    0x57,
-    0xad,
-    0xfe,
-    0x4f,
-    0xd3,
-    0x13,
-    0xcc,
-    0x9d,
-    0xc9,
-    0x40,
-    0xa6,
-    0x1e,
-    0x01,
-    0x17,
-    0x4e,
-    0x7e, //UUID
+    17, // 1 byte type + 16 byte UUID
+    AD_TYPE_COMPLETE_128BIT_SERVICE_UUIDS,
+    PROGRESSOR_SERVICE_UUID_LE[0],
+    PROGRESSOR_SERVICE_UUID_LE[1],
+    PROGRESSOR_SERVICE_UUID_LE[2],
+    PROGRESSOR_SERVICE_UUID_LE[3],
+    PROGRESSOR_SERVICE_UUID_LE[4],
+    PROGRESSOR_SERVICE_UUID_LE[5],
+    PROGRESSOR_SERVICE_UUID_LE[6],
+    PROGRESSOR_SERVICE_UUID_LE[7],
+    PROGRESSOR_SERVICE_UUID_LE[8],
+    PROGRESSOR_SERVICE_UUID_LE[9],
+    PROGRESSOR_SERVICE_UUID_LE[10],
+    PROGRESSOR_SERVICE_UUID_LE[11],
+    PROGRESSOR_SERVICE_UUID_LE[12],
+    PROGRESSOR_SERVICE_UUID_LE[13],
+    PROGRESSOR_SERVICE_UUID_LE[14],
+    PROGRESSOR_SERVICE_UUID_LE[15],
 ];
 
 // GATT Server definition

--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -9,6 +9,7 @@
 use core::fmt;
 
 use defmt::{debug, error, info};
+use embassy_time::{Duration, with_timeout};
 use embedded_hal::delay::DelayNs;
 use embedded_storage::{ReadStorage, Storage};
 use esp_hal::{
@@ -27,9 +28,15 @@ const HX711_DELAY_TIME_US: u32 = 1;
 const HX711_DATA_BITS: usize = 24;
 /// The sign bit position in the HX711 reading
 const HX711_SIGN_BIT: u32 = 0x800000;
+/// Timeout waiting for the HX711 data pin to signal readiness.
+const HX711_READY_TIMEOUT: Duration = Duration::from_millis(500);
 
-/// The default address of the NVS flash storage.
-const NVS_ADDR: u32 = 0x9000;
+/// Magic value used to validate stored calibration data.
+const CALIBRATION_STORAGE_MAGIC: u32 = 0x4344_5146;
+/// Storage format version for persisted calibration data.
+const CALIBRATION_STORAGE_VERSION: u32 = 1;
+/// Number of bytes used to store the persisted calibration blob.
+const CALIBRATION_STORAGE_SIZE: usize = 16;
 /// The default number of samples for taring
 const DEFAULT_TARING_SAMPLES: usize = 16;
 /// The default number of samples for calibration
@@ -44,6 +51,8 @@ pub enum Hx711Error {
     FlashError,
     /// Invalid calibration value
     InvalidCalibration,
+    /// Timed out waiting for the HX711 to become ready.
+    NotReadyTimeout,
 }
 
 impl fmt::Display for Hx711Error {
@@ -51,6 +60,7 @@ impl fmt::Display for Hx711Error {
         match self {
             Hx711Error::FlashError => write!(f, "Flash storage error"),
             Hx711Error::InvalidCalibration => write!(f, "Invalid calibration value"),
+            Hx711Error::NotReadyTimeout => write!(f, "HX711 ready timeout"),
         }
     }
 }
@@ -115,17 +125,48 @@ impl<'d> Hx711<'d> {
         hx711
     }
 
+    fn calibration_storage_offset(&self) -> Result<u32, Hx711Error> {
+        let capacity = self.flash.capacity();
+        let sector_size = FlashStorage::SECTOR_SIZE as usize;
+
+        if capacity < sector_size {
+            error!("Flash capacity too small for calibration storage");
+            return Err(Hx711Error::FlashError);
+        }
+
+        Ok((capacity - sector_size) as u32)
+    }
+
+    fn calibration_checksum(factor_bits: u32) -> u32 {
+        CALIBRATION_STORAGE_MAGIC ^ CALIBRATION_STORAGE_VERSION ^ factor_bits ^ 0xA5A5_5A5A
+    }
+
     /// Read calibration factor from flash
     fn read_from_flash(&mut self) -> Result<f32, Hx711Error> {
-        let mut bytes = [0u8; 4];
+        let mut bytes = [0u8; CALIBRATION_STORAGE_SIZE];
+        let offset = self.calibration_storage_offset()?;
 
-        self.flash.read(NVS_ADDR, &mut bytes).map_err(|_| {
+        self.flash.read(offset, &mut bytes).map_err(|_| {
             error!("Failed to read calibration factor from flash");
             Hx711Error::FlashError
         })?;
 
-        let factor = f32::from_le_bytes(bytes);
+        let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        let factor_bits = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        let checksum = u32::from_le_bytes(bytes[12..16].try_into().unwrap());
 
+        if magic != CALIBRATION_STORAGE_MAGIC || version != CALIBRATION_STORAGE_VERSION {
+            info!("Calibration storage missing or version mismatch");
+            return Err(Hx711Error::InvalidCalibration);
+        }
+
+        if checksum != Self::calibration_checksum(factor_bits) {
+            error!("Calibration storage checksum mismatch");
+            return Err(Hx711Error::InvalidCalibration);
+        }
+
+        let factor = f32::from_bits(factor_bits);
         if !Self::is_valid_calibration_factor(factor) {
             info!("Invalid calibration factor read from flash");
             return Err(Hx711Error::InvalidCalibration);
@@ -145,9 +186,16 @@ impl<'d> Hx711<'d> {
             return Err(Hx711Error::InvalidCalibration);
         }
 
-        let bytes = calibration_factor.to_le_bytes();
+        let factor_bits = calibration_factor.to_bits();
+        let checksum = Self::calibration_checksum(factor_bits);
+        let mut bytes = [0u8; CALIBRATION_STORAGE_SIZE];
+        bytes[0..4].copy_from_slice(&CALIBRATION_STORAGE_MAGIC.to_le_bytes());
+        bytes[4..8].copy_from_slice(&CALIBRATION_STORAGE_VERSION.to_le_bytes());
+        bytes[8..12].copy_from_slice(&factor_bits.to_le_bytes());
+        bytes[12..16].copy_from_slice(&checksum.to_le_bytes());
 
-        self.flash.write(NVS_ADDR, &bytes).map_err(|_| {
+        let offset = self.calibration_storage_offset()?;
+        self.flash.write(offset, &bytes).map_err(|_| {
             error!("Failed to write calibration factor to flash");
             Hx711Error::FlashError
         })?;
@@ -258,53 +306,54 @@ impl<'d> Hx711<'d> {
     }
 
     /// Waits until the data is ready to be read.
-    async fn wait_for_ready(&mut self) {
-        self.data.wait_for_low().await;
+    async fn wait_for_ready(&mut self) -> Result<(), Hx711Error> {
+        with_timeout(HX711_READY_TIMEOUT, self.data.wait_for_low())
+            .await
+            .map_err(|_| {
+                error!("Timed out waiting for HX711 ready signal");
+                Hx711Error::NotReadyTimeout
+            })
     }
 
     /// Takes multiple samples and returns the average
-    async fn take_samples(&mut self, num_samples: usize) -> f32 {
+    async fn take_samples(&mut self, num_samples: usize) -> Result<f32, Hx711Error> {
         let mut total: f32 = 0.0;
 
         for _ in 0..num_samples {
-            self.wait_for_ready().await;
+            self.wait_for_ready().await?;
             total += self.read_raw() as f32;
         }
 
-        total / num_samples as f32
+        Ok(total / num_samples as f32)
     }
 
     /// Tares the sensor by measuring the average of several readings.
-    pub async fn tare(&mut self) {
+    pub async fn tare(&mut self) -> Result<(), Hx711Error> {
         debug!("Taring the scale");
-        if !Self::is_valid_calibration_factor(self.calibration_factor) {
-            info!("Invalid calibration factor, skipping tare");
-            return;
-        }
-
-        let average = self.take_samples(DEFAULT_TARING_SAMPLES).await;
+        let average = self.take_samples(DEFAULT_TARING_SAMPLES).await?;
         self.tare_value = average as i32;
         debug!("Tare value set to: {}", self.tare_value);
+        Ok(())
     }
 
     /// Reads a raw value without calibration
-    pub async fn read_raw_value(&mut self) -> i32 {
-        self.wait_for_ready().await;
-        self.read_raw()
+    pub async fn read_raw_value(&mut self) -> Result<i32, Hx711Error> {
+        self.wait_for_ready().await?;
+        Ok(self.read_raw())
     }
 
     /// Reads a tared raw value (raw value minus tare value)
-    pub async fn read_tared(&mut self) -> i32 {
-        self.wait_for_ready().await;
-        self.read_raw() - self.tare_value
+    pub async fn read_tared(&mut self) -> Result<i32, Hx711Error> {
+        self.wait_for_ready().await?;
+        Ok(self.read_raw() - self.tare_value)
     }
 
     /// Reads a calibrated value, in kg.
-    pub async fn read_calibrated(&mut self) -> f32 {
-        let raw_tared = self.read_tared().await;
+    pub async fn read_calibrated(&mut self) -> Result<f32, Hx711Error> {
+        let raw_tared = self.read_tared().await?;
         let calibrated_value = (raw_tared as f32) * self.calibration_factor;
         // Convert to kg
-        calibrated_value / 1000.0
+        Ok(calibrated_value / 1000.0)
     }
 
     /// Perform two-point calibration with a known target weight
@@ -313,19 +362,12 @@ impl<'d> Hx711<'d> {
     /// and averaging them for stability.
     ///
     /// Returns the average raw value for the calibration point.
-    pub async fn perform_calibration(&mut self) -> f32 {
-        // Reset calibration to raw values first
-        if let Err(e) = self.update_calibration_factor(1.0) {
-            error!(
-                "Failed to reset calibration factor before calibration: {:?}",
-                defmt::Debug2Format(&e)
-            );
-        }
-        // Take multiple readings and average them for stability
-        let average_value = self.take_samples(DEFAULT_CALIBRATION_SAMPLES).await;
+    pub async fn perform_calibration(&mut self) -> Result<f32, Hx711Error> {
+        // Take multiple readings and average them for stability using raw values.
+        let average_value = self.take_samples(DEFAULT_CALIBRATION_SAMPLES).await?;
         debug!("Calibration point collected: {}", average_value);
 
-        average_value
+        Ok(average_value)
     }
 
     /// Apply multi-point calibration using the collected calibration points.

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,8 @@ use embassy_futures::{join::join, select::select};
 use embassy_sync::channel::Channel;
 use embassy_time::{Duration, Timer};
 use esp_hal::{
-    Async, Config,
+    Async,
+    Config,
     analog::adc::{Adc, AdcCalCurve, AdcConfig, AdcPin, Attenuation},
     clock::CpuClock,
     delay::Delay,
@@ -32,8 +33,14 @@ use crate::{
     ble::{CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU, Server, advertise},
     hx711::Hx711,
     progressor::{
-        CalibrationPoint, ControlOpCode, DataPoint, DataPointChannel, DeviceState,
-        MAX_CALIBRATION_POINTS, MeasurementTaskStatus, ResponseCode,
+        CalibrationPoint,
+        ControlOpCode,
+        DataPoint,
+        DataPointChannel,
+        DeviceState,
+        MAX_CALIBRATION_POINTS,
+        MeasurementTaskStatus,
+        ResponseCode,
     },
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,7 @@ async fn main(spawner: Spawner) -> ! {
             match advertise(device_name, &mut peripheral, &server).await {
                 Ok(conn) => {
                     info!("BLE connection established");
+                    channel.clear();
                     critical_section::with(|cs| {
                         DEVICE_STATE.borrow_ref_mut(cs).on_ble_connected();
                     });
@@ -175,6 +176,7 @@ async fn main(spawner: Spawner) -> ! {
                         data_processing_task(&server, &conn, channel),
                     )
                     .await;
+                    channel.clear();
                     critical_section::with(|cs| {
                         let mut state = DEVICE_STATE.borrow_ref_mut(cs);
                         state.stop_measurement();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,7 @@ use embassy_futures::{join::join, select::select};
 use embassy_sync::channel::Channel;
 use embassy_time::{Duration, Timer};
 use esp_hal::{
-    Async,
-    Config,
+    Async, Config,
     analog::adc::{Adc, AdcCalCurve, AdcConfig, AdcPin, Attenuation},
     clock::CpuClock,
     delay::Delay,
@@ -33,14 +32,8 @@ use crate::{
     ble::{CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU, Server, advertise},
     hx711::Hx711,
     progressor::{
-        CalibrationPoint,
-        ControlOpCode,
-        DataPoint,
-        DataPointChannel,
-        DeviceState,
-        MAX_CALIBRATION_POINTS,
-        MeasurementTaskStatus,
-        ResponseCode,
+        CalibrationPoint, ControlOpCode, DataPoint, DataPointChannel, DeviceState,
+        MAX_CALIBRATION_POINTS, MeasurementTaskStatus, ResponseCode,
     },
 };
 
@@ -284,7 +277,9 @@ async fn measurement_task(
     flash: FlashStorage<'static>,
 ) {
     let mut load_cell = Hx711::new(data_pin, clock_pin, delay, flash);
-    load_cell.tare().await;
+    if let Err(e) = load_cell.tare().await {
+        error!("Initial tare failed: {:?}", defmt::Debug2Format(&e));
+    }
 
     loop {
         // Get current device state
@@ -299,7 +294,9 @@ async fn measurement_task(
             }
             MeasurementTaskStatus::Tare => {
                 // Perform taring operation
-                load_cell.tare().await;
+                if let Err(e) = load_cell.tare().await {
+                    error!("Tare failed: {:?}", defmt::Debug2Format(&e));
+                }
 
                 critical_section::with(|cs| {
                     let mut state = DEVICE_STATE.borrow_ref_mut(cs);
@@ -320,7 +317,17 @@ async fn measurement_task(
                 }
 
                 // Use the load cell's own calibration method to collect a calibration point
-                let calibration_point = load_cell.perform_calibration().await;
+                let calibration_point = match load_cell.perform_calibration().await {
+                    Ok(calibration_point) => calibration_point,
+                    Err(e) => {
+                        error!("Calibration sampling failed: {:?}", defmt::Debug2Format(&e));
+                        critical_section::with(|cs| {
+                            DEVICE_STATE.borrow_ref_mut(cs).measurement_status =
+                                MeasurementTaskStatus::Disabled;
+                        });
+                        continue;
+                    }
+                };
                 if !calibration_point.is_finite() {
                     error!(
                         "Ignoring invalid calibration raw point: {}",
@@ -357,8 +364,9 @@ async fn measurement_task(
                     if !load_cell.apply_multi_point_calibration(points) {
                         error!("Failed to apply calibration points: {:?}", points);
                     } else {
-                        notify_calibration_factor(channel, load_cell.current_calibration_factor());
-                        notify_calibration_points(channel, points);
+                        notify_calibration_factor(channel, load_cell.current_calibration_factor())
+                            .await;
+                        notify_calibration_points(channel, points).await;
                     }
                 } else {
                     info!("Calibration needs at least two points before applying.");
@@ -372,7 +380,8 @@ async fn measurement_task(
                         defmt::Debug2Format(&e)
                     );
                 } else {
-                    notify_calibration_factor(channel, load_cell.current_calibration_factor());
+                    notify_calibration_factor(channel, load_cell.current_calibration_factor())
+                        .await;
                 }
                 critical_section::with(|cs| {
                     let mut state = DEVICE_STATE.borrow_ref_mut(cs);
@@ -383,7 +392,9 @@ async fn measurement_task(
             MeasurementTaskStatus::GetCalibration => {
                 match load_cell.get_calibration_factor() {
                     Ok(factor) => {
-                        DataPoint::from(ResponseCode::CalibrationFactor(factor)).send(channel);
+                        DataPoint::from(ResponseCode::CalibrationFactor(factor))
+                            .send(channel)
+                            .await;
                     }
                     Err(e) => {
                         error!(
@@ -392,23 +403,23 @@ async fn measurement_task(
                         );
                     }
                 }
-                critical_section::with(|cs| {
+
+                let (calibration_points, calibration_point_count) = critical_section::with(|cs| {
                     let mut state = DEVICE_STATE.borrow_ref_mut(cs);
-                    let calibration_point_count = state.calibration_point_count;
-                    notify_calibration_points(
-                        channel,
-                        &state.calibration_points[..calibration_point_count],
-                    );
-                    if state.calibration_point_count > 0 {
-                        info!(
-                            "Calibration points: {:?}",
-                            &state.calibration_points[..state.calibration_point_count]
-                        );
-                    } else {
-                        info!("Calibration points empty (possibly lost after device reset)");
-                    }
                     state.measurement_status = MeasurementTaskStatus::Disabled;
+                    (state.calibration_points, state.calibration_point_count)
                 });
+
+                notify_calibration_points(channel, &calibration_points[..calibration_point_count])
+                    .await;
+                if calibration_point_count > 0 {
+                    info!(
+                        "Calibration points: {:?}",
+                        &calibration_points[..calibration_point_count]
+                    );
+                } else {
+                    info!("Calibration points empty (possibly lost after device reset)");
+                }
             }
         }
 
@@ -425,7 +436,16 @@ async fn send_weight_measurement(
     start_time: u32,
     channel: &'static DataPointChannel,
 ) {
-    let weight = load_cell.read_calibrated().await;
+    let weight = match load_cell.read_calibrated().await {
+        Ok(weight) => weight,
+        Err(e) => {
+            error!(
+                "Failed to read weight measurement: {:?}",
+                defmt::Debug2Format(&e)
+            );
+            return;
+        }
+    };
     let now = (time::Instant::now().duration_since_epoch()).as_micros() as u32;
     let timestamp = now.wrapping_sub(start_time);
 
@@ -435,22 +455,28 @@ async fn send_weight_measurement(
         timestamp as f32 / 1000000.0
     );
 
-    DataPoint::weight_measurement(weight, timestamp).send(channel);
+    DataPoint::weight_measurement(weight, timestamp)
+        .send(channel)
+        .await;
 }
 
-fn notify_calibration_points(
+async fn notify_calibration_points(
     channel: &'static DataPointChannel,
     calibration_points: &[CalibrationPoint],
 ) {
     for (raw_value, weight) in calibration_points {
         debug!("Notifying calibration point: {:?}", (raw_value, weight));
-        DataPoint::from(ResponseCode::CalibrationPoint(*raw_value, *weight)).send(channel);
+        DataPoint::from(ResponseCode::CalibrationPoint(*raw_value, *weight))
+            .send(channel)
+            .await;
     }
 }
 
-fn notify_calibration_factor(channel: &'static DataPointChannel, calibration_factor: f32) {
+async fn notify_calibration_factor(channel: &'static DataPointChannel, calibration_factor: f32) {
     debug!("Notifying calibration factor: {:?}", calibration_factor);
-    DataPoint::from(ResponseCode::CalibrationFactor(calibration_factor)).send(channel);
+    DataPoint::from(ResponseCode::CalibrationFactor(calibration_factor))
+        .send(channel)
+        .await;
 }
 
 /// Stream Events until the connection closes.
@@ -470,29 +496,42 @@ async fn gatt_events_task<P: PacketPool>(
                 break;
             }
             GattConnectionEvent::Gatt { event } => {
-                // Handle write events to the control point
-                if let GattEvent::Write(write_event) = &event
+                let immediate_response = if let GattEvent::Write(write_event) = &event
                     && write_event.handle() == control_point.handle
                 {
                     let cmd_data = write_event.data();
-                    let Some(&op_code_byte) = cmd_data.first() else {
-                        warn!("Control Point write with empty payload");
-                        continue;
-                    };
-                    let op_code = ControlOpCode::from(op_code_byte);
-                    info!("Control Point Received: {:?}", op_code);
-
-                    critical_section::with(|cs| {
-                        let mut device_state = DEVICE_STATE.borrow_ref_mut(cs);
-                        op_code.process(cmd_data, channel, &mut device_state);
-                    });
-                }
+                    match cmd_data.first().copied() {
+                        Some(op_code_byte) => match ControlOpCode::try_from(op_code_byte) {
+                            Ok(op_code) => {
+                                info!("Control Point Received: {:?}", op_code);
+                                critical_section::with(|cs| {
+                                    let mut device_state = DEVICE_STATE.borrow_ref_mut(cs);
+                                    op_code.process(cmd_data, &mut device_state)
+                                })
+                            }
+                            Err(()) => {
+                                warn!("Ignoring unsupported OpCode: {:#x}", op_code_byte);
+                                None
+                            }
+                        },
+                        None => {
+                            warn!("Control Point write with empty payload");
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
 
                 // Ensure reply is sent
                 if let Ok(reply) = event.accept() {
                     reply.send().await;
                 } else {
                     warn!("Error sending response");
+                }
+
+                if let Some(response) = immediate_response {
+                    response.send(channel).await;
                 }
             }
             _ => {}

--- a/src/progressor.rs
+++ b/src/progressor.rs
@@ -3,7 +3,7 @@
 /// See [Tindeq API documentation] for more information
 ///
 /// [Tindeq API documentation]: https://tindeq.com/progressor_api/
-use defmt::{Format, error, info, trace, warn};
+use defmt::{Format, error, info, warn};
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, channel::Channel};
 use esp_hal::time;
 use trouble_host::types::gatt_traits::{AsGatt, FromGatt, FromGattError};
@@ -169,27 +169,27 @@ pub enum ControlOpCode {
 }
 
 impl ControlOpCode {
-    /// Process the control operation
-    pub fn process(
-        self,
-        data: &[u8],
-        channel: &'static DataPointChannel,
-        device_state: &mut DeviceState,
-    ) {
+    /// Process the control operation.
+    ///
+    /// Returns an immediate response packet when the command requires one.
+    pub fn process(self, data: &[u8], device_state: &mut DeviceState) -> Option<DataPoint> {
         match self {
             ControlOpCode::TareScale => {
                 device_state.tare();
+                None
             }
             ControlOpCode::StartMeasurement => {
                 device_state.start_measurement();
+                None
             }
             ControlOpCode::StopMeasurement => {
                 device_state.stop_measurement();
+                None
             }
             ControlOpCode::GetAppVersion => {
                 let response = ResponseCode::AppVersion(env!("DEVICE_VERSION_NUMBER").as_bytes());
                 info!("AppVersion: {:#x}", response);
-                DataPoint::from(response).send(channel);
+                Some(DataPoint::from(response))
             }
             ControlOpCode::GetProgressorId => {
                 /// Number of hex characters needed per byte (2 hex chars = 1 byte)
@@ -211,29 +211,30 @@ impl ControlOpCode {
                 }
                 let response = ResponseCode::ProgressorId(bytes);
                 info!("ProgressorId: {:?}", response);
-                DataPoint::from(response).send(channel);
+                Some(DataPoint::from(response))
             }
             ControlOpCode::GetCalibration => {
                 info!("GetCalibration requested");
                 device_state.get_calibration();
+                None
             }
             ControlOpCode::AddCalibrationPoint => {
                 if data.len() < 5 {
                     error!("AddCalibrationPoint: Invalid data length");
-                    return;
+                    return None;
                 }
 
                 let weight = match data[1..5].try_into() {
                     Ok(bytes) => f32::from_le_bytes(bytes),
                     Err(e) => {
                         error!("Failed to parse calibration point data: {:?}", e);
-                        return;
+                        return None;
                     }
                 };
 
                 if !weight.is_finite() || weight < 0.0 {
                     error!("AddCalibrationPoint: Invalid weight {}", weight);
-                    return;
+                    return None;
                 }
 
                 device_state.calibrate(weight);
@@ -241,48 +242,52 @@ impl ControlOpCode {
                     "Received AddCalibrationPoint command with measurement: {}",
                     weight
                 );
+                None
             }
             ControlOpCode::DefaultCalibration => {
                 device_state.reset_calibration();
+                None
             }
             ControlOpCode::SampleBattery => {
                 let voltage = device_state.battery_voltage;
                 let response = ResponseCode::SampleBatteryVoltage(voltage);
                 info!("SampleBattery: {:?}", response);
-                DataPoint::from(response).send(channel);
+                Some(DataPoint::from(response))
             }
             // Currently unimplemented operations
-            ControlOpCode::Shutdown => {}
-            ControlOpCode::StartPeakRFDMeasurement => {}
-            ControlOpCode::StartPeakRFDMeasurementSeries => {}
-            ControlOpCode::SaveCalibration => {}
-            ControlOpCode::ClearErrorInformation => {}
-            ControlOpCode::GetErrorInformation => {}
+            ControlOpCode::Shutdown
+            | ControlOpCode::StartPeakRFDMeasurement
+            | ControlOpCode::StartPeakRFDMeasurementSeries
+            | ControlOpCode::SaveCalibration
+            | ControlOpCode::ClearErrorInformation
+            | ControlOpCode::GetErrorInformation => None,
         }
     }
 }
 
-impl From<u8> for ControlOpCode {
-    fn from(op_code: u8) -> Self {
+impl TryFrom<u8> for ControlOpCode {
+    type Error = ();
+
+    fn try_from(op_code: u8) -> Result<Self, Self::Error> {
         match op_code {
-            0x64 => ControlOpCode::TareScale,
-            0x65 => ControlOpCode::StartMeasurement,
-            0x66 => ControlOpCode::StopMeasurement,
-            0x69 => ControlOpCode::AddCalibrationPoint,
-            0x6E => ControlOpCode::Shutdown,
-            0x6F => ControlOpCode::SampleBattery,
-            0x70 => ControlOpCode::GetProgressorId,
-            0x6B => ControlOpCode::GetAppVersion,
-            0x72 => ControlOpCode::GetCalibration,
-            0x74 => ControlOpCode::DefaultCalibration,
-            0x6C => ControlOpCode::GetErrorInformation,
-            0x6D => ControlOpCode::ClearErrorInformation,
-            0x67 => ControlOpCode::StartPeakRFDMeasurement,
-            0x68 => ControlOpCode::StartPeakRFDMeasurementSeries,
-            0x6A => ControlOpCode::SaveCalibration,
+            0x64 => Ok(ControlOpCode::TareScale),
+            0x65 => Ok(ControlOpCode::StartMeasurement),
+            0x66 => Ok(ControlOpCode::StopMeasurement),
+            0x69 => Ok(ControlOpCode::AddCalibrationPoint),
+            0x6E => Ok(ControlOpCode::Shutdown),
+            0x6F => Ok(ControlOpCode::SampleBattery),
+            0x70 => Ok(ControlOpCode::GetProgressorId),
+            0x6B => Ok(ControlOpCode::GetAppVersion),
+            0x72 => Ok(ControlOpCode::GetCalibration),
+            0x74 => Ok(ControlOpCode::DefaultCalibration),
+            0x6C => Ok(ControlOpCode::GetErrorInformation),
+            0x6D => Ok(ControlOpCode::ClearErrorInformation),
+            0x67 => Ok(ControlOpCode::StartPeakRFDMeasurement),
+            0x68 => Ok(ControlOpCode::StartPeakRFDMeasurementSeries),
+            0x6A => Ok(ControlOpCode::SaveCalibration),
             _ => {
                 error!("Invalid OpCode received: {:#x}", op_code);
-                ControlOpCode::StopMeasurement
+                Err(())
             }
         }
     }
@@ -377,13 +382,9 @@ impl DataPoint {
         }
     }
 
-    /// Send data point to the channel
-    pub fn send(&self, channel: &'static DataPointChannel) {
-        if channel.try_send(*self).is_err() {
-            error!("Failed to send data point: channel full or receiver dropped");
-        } else {
-            trace!("Sent data point successfully");
-        }
+    /// Send data point to the channel.
+    pub async fn send(self, channel: &'static DataPointChannel) {
+        channel.send(self).await;
     }
 
     /// Create a weight measurement data point


### PR DESCRIPTION
 - Fixed BLE scan response encoding for the advertised 128-bit service UUID                                       
 - Replaced hardcoded calibration flash storage with a validated persisted blob                                   
 - Removed the unnecessary temporary 1.0 calibration write during calibration                                     
 - Ignored unsupported opcodes instead of mapping them to StopMeasurement                                         
 - Switched datapoint sending to async queueing and cleared stale notifications on reconnect                      
 - Added a timeout while waiting for the HX711 to become ready     