### PR TITLE
Update deps to  esp-hal@1.1 and company

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
 [alias]
 bin = "espflash save-image --chip esp32c3 crimpdeq.bin"
 bin-merged = "espflash save-image --chip esp32c3 crimpdeq.bin --merge"
+flash = "espflash flash --chip esp32c3"
 
 [target.riscv32imc-unknown-none-elf]
 runner = "probe-rs run --chip esp32c3 --no-location --preverify --restore-unwritten --always-print-stacktrace"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -72,9 +72,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -87,24 +87,24 @@ dependencies = [
 
 [[package]]
 name = "bt-hci"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f2166cc54c410ddc0d0dafb3cf8dd536bcbae6bddfcc12c020c5ee4de518de"
+checksum = "211713d2e9fb4793ce4360a712c0764264aff6be48932ccf02ca2a331c0436a9"
 dependencies = [
  "btuuid",
  "defmt 1.0.1",
- "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
  "embedded-io 0.7.1",
  "embedded-io-async 0.7.0",
  "futures-intrusive",
- "heapless 0.9.2",
+ "heapless 0.9.3",
 ]
 
 [[package]]
 name = "btuuid"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0acfef8a77a02866e04f7e2ad3f4c7b32d575696c49c4bbad742b4aecb8e4a3"
+checksum = "f5f48f1e9b0aad0a4f05d17bdeae0fa20ff798e272a03a6940ca27ad9c5a6ae7"
 dependencies = [
  "defmt 0.3.100",
  "uuid",
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byte"
@@ -124,9 +124,9 @@ checksum = "21c7ab3e4ae80853c7f8dcdcd904dfa25c02cc373534b8d165194325a088a7cc"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -136,9 +136,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -288,7 +288,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -301,7 +301,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -325,7 +325,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -336,7 +336,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -347,7 +347,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -379,7 +379,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -399,7 +399,7 @@ checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -429,7 +429,7 @@ checksum = "11772ed3eb3db124d826f3abeadf5a791a557f62c19b123e3f07288158a71fdd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -481,7 +481,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -549,7 +549,7 @@ dependencies = [
  "embedded-io-async 0.7.0",
  "futures-core",
  "futures-sink",
- "heapless 0.9.2",
+ "heapless 0.9.3",
 ]
 
 [[package]]
@@ -580,12 +580,12 @@ dependencies = [
 
 [[package]]
 name = "embassy-time-queue-utils"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e2ee86063bd028a420a5fb5898c18c87a8898026da1d4c852af2c443d0a454"
+checksum = "168297bf80aaf114b3c9ad589bf38b01b3009b9af7f97cd18086c5bbf96f5693"
 dependencies = [
  "embassy-executor-timer-queue",
- "heapless 0.8.0",
+ "heapless 0.9.3",
 ]
 
 [[package]]
@@ -694,7 +694,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -752,12 +752,12 @@ dependencies = [
 
 [[package]]
 name = "esp-hal"
-version = "1.1.0-rc.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3599174af043c640b89d5950558bc40bd448f6e1d56ae43880a0d8530b4f82c"
+checksum = "6af8fa8216bc126941bd43b5a200a50eab16e43881ccd0dd0b6792f4a82805f0"
 dependencies = [
  "bitfield",
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "cfg-if",
  "critical-section",
@@ -798,7 +798,7 @@ dependencies = [
  "portable-atomic",
  "rand_core 0.10.1",
  "rand_core 0.6.4",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "riscv",
  "strum",
  "ufmt-write",
@@ -816,7 +816,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "termcolor",
 ]
 
@@ -878,7 +878,7 @@ dependencies = [
  "esp-wifi-sys-esp32s2",
  "esp-wifi-sys-esp32s3",
  "esp32c3",
- "heapless 0.9.2",
+ "heapless 0.9.3",
  "ieee802154",
  "instability",
  "num-derive",
@@ -1047,99 +1047,90 @@ dependencies = [
 
 [[package]]
 name = "esp32"
-version = "0.40.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea414047c2efb3bbc5e394dd1fe09016d27db92b4fbf2fc9a00b6b813de27884"
+checksum = "5726e07689249d1a2cb7c492077bc424837fb68a64f7eb5d46569325352e9428"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32c2"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fad8c1395fc135f86c67e0b2052304e7575602f17af542c1ba67110e819fb5a"
+checksum = "5ef0b623533bbaa37e348c18b6b41cfd5b47c3cb64a4b9e44f0295941d62aa2e"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32c3"
-version = "0.32.0"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8d61ef69888501c679b7ec42cd6d79d1e0d210d96c929ecc100fffdc02f3eb"
+checksum = "21e89ed62cf6c043a6d29c520b02a13b359ec8a75d67b65d4330ed717d15fe97"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32c5"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2f7fc6e2be17c362ecad32a4eb9b2d2ec9ea6a23cd08fcb93e8984369ad222"
+checksum = "a6f8ba56195df10224263c60ceb93b4578450019ee838b7338039a281117cb02"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32c6"
-version = "0.23.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad5c007b1bc73bc1ff1c076abd67770cfa0a364553abe3c0c4d62a3e0645d02"
+checksum = "c58f34ff2633968c12125efc7f4f8f101078d5d34c7cb60eab82268db20986f9"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32c61"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e18d316b49ea47baa7004d729cc90f4a0ab53828762f6bfc296a04e816c0c2"
+checksum = "2a926616351b1edfdb50b7ea6451a8dff0c7515c6ceb687063af7d32b117ec0d"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32h2"
-version = "0.19.0"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f45a76fec7d2c3ee1213f89e66ade3d0f368ea7d45f88203e91bfe1fe4ec9c75"
+checksum = "c5bab026020ed4606ce113b6fde598dbc48f7eefcc46e9469ece77cc2b1aa4be"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32s2"
-version = "0.31.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b09e7c54ac8c902203433ad9b1d3cd4b477a4fe669befdd9714dcef5d269d1"
+checksum = "d0ad6f21cdf6ec7b06b7f7e0fbe51f0d975fd6a5fa67c3f8a5a910d3981af531"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32s3"
-version = "0.35.0"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4519c25f8442f92d51feccc7bb87981b2a2a3c4b0ff512845b39fbdddd95d9bc"
+checksum = "8b4b8c4e4d9f187553ecdb7173edec7b2deb2beea106eedefecdb1654b8ee25a"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
@@ -1168,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1182,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1192,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-intrusive"
@@ -1208,33 +1199,33 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1299,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heapless"
@@ -1315,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
  "defmt 1.0.1",
  "hash32 0.3.1",
@@ -1352,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1379,20 +1370,20 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.17"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87d9b8105c23642f50cbbae03d1f75d8422c5cb98ce7ee9271f7ff7505be6b8"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -1403,21 +1394,23 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.17"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b787bebb543f8969132630c51fd0afab173a86c6abae56ff3b9e5e3e3f9f6e58"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1430,15 +1423,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
+checksum = "2b23ac50abb8261cb38c6e2a7192d3302e0836dac1628f6a93b82b4fad185897"
 
 [[package]]
 name = "litrs"
@@ -1485,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nb"
@@ -1521,7 +1514,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1535,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "panic-rtt-target"
@@ -1559,27 +1552,21 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -1602,14 +1589,14 @@ checksum = "a33fa6ec7f2047f572d49317cca19c87195de99c6e5b6ee492da701cfe02b053"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -1633,23 +1620,23 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.104"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1662,9 +1649,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
 name = "rand_core"
@@ -1710,7 +1697,7 @@ checksum = "7d323d13972c1b104aa036bc692cd08b822c8bbf23d79a27c526095856499799"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1740,7 +1727,7 @@ checksum = "def519ddeeb5e43c2b4fc3952c27b3a86782fc05192f322b2309125cd85b1fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1751,13 +1738,14 @@ checksum = "b1376b15f3ff160e9b1e8ea564ce427f2f6fcf77528cc0a8bf405cb476f9cea7"
 
 [[package]]
 name = "rlsf"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222fb240c3286247ecdee6fa5341e7cdad0ffdf8e7e401d9937f2d58482a20bf"
+checksum = "1646a59a9734b8b7a0ac51689388a60fe1625d4b956348e9de07591a1478457a"
 dependencies = [
  "cfg-if",
  "const-default",
  "libc",
+ "rustversion",
  "svgbobdoc",
 ]
 
@@ -1781,9 +1769,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scoped-tls"
@@ -1824,7 +1812,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1854,6 +1842,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1915,7 +1909,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1950,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1970,22 +1964,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1999,18 +1993,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2020,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -2046,7 +2040,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2101,7 +2095,7 @@ dependencies = [
  "embassy-time",
  "embedded-io 0.7.1",
  "futures",
- "heapless 0.9.2",
+ "heapless 0.9.3",
  "rand_core 0.6.4",
  "static_cell",
  "trouble-host-macros",
@@ -2118,15 +2112,15 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "uuid",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ufmt-write"
@@ -2136,15 +2130,15 @@ checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -2160,9 +2154,9 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2194,9 +2188,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2207,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2217,22 +2211,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -2272,9 +2266,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -2308,25 +2302,25 @@ checksum = "96fb42cd29c42f8744c74276e9f5bee7b06685bbe5b88df891516d72cb320450"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,8 +705,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "esp-alloc"
-version = "0.9.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46ced060d4085858283df950b80a4da2348e1707d7d07b1e966308582dae79f5"
 dependencies = [
  "allocator-api2",
  "cfg-if",
@@ -721,8 +722,9 @@ dependencies = [
 
 [[package]]
 name = "esp-bootloader-esp-idf"
-version = "0.4.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ffc117c3a9859835d89d0e90f5ee9886ce2264a71a849a7a22ab5308f6653c"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -737,8 +739,9 @@ dependencies = [
 
 [[package]]
 name = "esp-config"
-version = "0.6.1"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d9b92fd9cfb0b4f8f1b6219b9763269a335571e307b014903b8201619374b80"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
@@ -749,8 +752,9 @@ dependencies = [
 
 [[package]]
 name = "esp-hal"
-version = "1.0.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "1.1.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3599174af043c640b89d5950558bc40bd448f6e1d56ae43880a0d8530b4f82c"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -804,8 +808,9 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-procmacros"
-version = "0.21.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aebfabb2c21bec45e575e4f6cb6bb7aa8e1b33e7ac45b5dffa0f9d33ff59105"
 dependencies = [
  "document-features",
  "proc-macro-crate",
@@ -817,13 +822,15 @@ dependencies = [
 
 [[package]]
 name = "esp-metadata-generated"
-version = "0.3.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c2ee95b945a4780796e4359e72c033aed3b45073880e8029458f538532db8a"
 
 [[package]]
 name = "esp-phy"
-version = "0.1.1"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c0a29815cd105ae1a02f3d0c6e7aafda9504a41effae17fac4c3f827719228"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",
@@ -839,8 +846,9 @@ dependencies = [
 
 [[package]]
 name = "esp-radio"
-version = "0.17.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fbff98b06a96b6ce3791ecec5c668524052a068e23aacd23afe17ddba844ce"
 dependencies = [
  "allocator-api2",
  "bt-hci",
@@ -881,8 +889,9 @@ dependencies = [
 
 [[package]]
 name = "esp-radio-rtos-driver"
-version = "0.2.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd75cd9073a90ffaa53db0bf17df7dc14164f2407a6ff36c725d2d1f78ff494"
 dependencies = [
  "cfg-if",
  "esp-sync",
@@ -891,8 +900,9 @@ dependencies = [
 
 [[package]]
 name = "esp-riscv-rt"
-version = "0.13.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a814ae91452de56a5e74f69aebfee40579511756837d3774a56fd24cf0ab79"
 dependencies = [
  "defmt 1.0.1",
  "document-features",
@@ -902,8 +912,9 @@ dependencies = [
 
 [[package]]
 name = "esp-rom-sys"
-version = "0.1.3"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae852ccb08971155023d1371c96d5490cbc26860f06aee2d629ef73f1a890c3"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -913,8 +924,9 @@ dependencies = [
 
 [[package]]
 name = "esp-rtos"
-version = "0.2.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551f90766e1527edaa0c91e8d559e9e2a60397b545e93357ac61fb31845e5712"
 dependencies = [
  "allocator-api2",
  "cfg-if",
@@ -939,8 +951,9 @@ dependencies = [
 
 [[package]]
 name = "esp-storage"
-version = "0.8.1"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf2b3f00c9f94b27c62a4f5296b19470c3a083c687c8146e554a459f9bee596"
 dependencies = [
  "defmt 1.0.1",
  "document-features",
@@ -954,8 +967,9 @@ dependencies = [
 
 [[package]]
 name = "esp-sync"
-version = "0.1.1"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4736bfbbb9e3f6353344e14fc61b6d18d3b877c3286914cf8c0a037be0ed224"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",
@@ -2268,15 +2282,17 @@ dependencies = [
 [[package]]
 name = "xtensa-lx"
 version = "0.13.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e012d667b0aa6d2592ace8ef145a98bff3e76cca7a644f4181ecd7a916ed289b"
 dependencies = [
  "critical-section",
 ]
 
 [[package]]
 name = "xtensa-lx-rt"
-version = "0.21.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409a9b4629d429e995cde4dfbd9fe562ccae66f7624514e200733fc5d0ea8905"
 dependencies = [
  "defmt 1.0.1",
  "document-features",
@@ -2287,7 +2303,8 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
 version = "0.5.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96fb42cd29c42f8744c74276e9f5bee7b06685bbe5b88df891516d72cb320450"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,28 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
-
-[[package]]
-name = "anyhow"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arrayvec"
@@ -65,16 +77,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
-name = "bt-hci"
-version = "0.6.0"
+name = "block-buffer"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb938a3b4c5cc6c2409275bad789c0346a0495fa071a0acc5d72b9bd3175a2f7"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bt-hci"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f2166cc54c410ddc0d0dafb3cf8dd536bcbae6bddfcc12c020c5ee4de518de"
 dependencies = [
  "btuuid",
  "defmt 1.0.1",
  "embassy-sync 0.7.2",
- "embedded-io 0.6.1",
- "embedded-io-async 0.6.1",
+ "embedded-io 0.7.1",
+ "embedded-io-async 0.7.0",
  "futures-intrusive",
  "heapless 0.9.2",
 ]
@@ -96,6 +117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "byte"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21c7ab3e4ae80853c7f8dcdcd904dfa25c02cc373534b8d165194325a088a7cc"
+
+[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,10 +135,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "ccm"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9cf981c7e62b6fb02225592ee7ebf221e0b0b5317984a57a1e9d21af20e317"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "const-default"
@@ -126,6 +184,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cordyceps"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+dependencies = [
+ "loom",
+ "tracing",
 ]
 
 [[package]]
@@ -171,6 +239,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +265,16 @@ checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
  "darling_core 0.21.3",
  "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -218,6 +305,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +335,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.111",
 ]
@@ -297,7 +408,28 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
+ "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "docsplay"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8547ea80db62c5bb9d7796fcce5e6e07d1136bdc1a02269095061e806758fab4"
+dependencies = [
+ "docsplay-macros",
+]
+
+[[package]]
+name = "docsplay-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11772ed3eb3db124d826f3abeadf5a791a557f62c19b123e3f07288158a71fdd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -311,13 +443,13 @@ dependencies = [
 
 [[package]]
 name = "embassy-embedded-hal"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554e3e840696f54b4c9afcf28a0f24da431c927f4151040020416e7393d6d0d8"
+checksum = "b0641612053b2f34fc250bb63f6630ae75de46e02ade7f457268447081d709ce"
 dependencies = [
  "embassy-futures",
  "embassy-hal-internal",
- "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -328,10 +460,11 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06070468370195e0e86f241c8e5004356d696590a678d47d6676795b2e439c6b"
+checksum = "5d0d3b15c9d7dc4fec1d8cb77112472fb008b3b28c51ad23838d83587a6d2f1e"
 dependencies = [
+ "cordyceps",
  "critical-section",
  "defmt 1.0.1",
  "document-features",
@@ -341,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdddc3a04226828316bf31393b6903ee162238576b1584ee2669af215d55472"
+checksum = "d11a246f53de5f97a387f40ac24726817cd0b6f833e7603baac784f29d6ff276"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -368,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-hal-internal"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95285007a91b619dc9f26ea8f55452aa6c60f7115a4edc05085cd2bd3127cd7a"
+checksum = "7f10ce10a4dfdf6402d8e9bd63128986b96a736b1a0a6680547ed2ac55d55dba"
 dependencies = [
  "num-traits",
 ]
@@ -405,10 +538,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "embassy-time"
-version = "0.5.0"
+name = "embassy-sync"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa65b9284d974dad7a23bb72835c4ec85c0b540d86af7fc4098c88cff51d65"
+checksum = "7bbd85cf5a5ae56bdf26f618364af642d1d0a4e245cdd75cd9aabda382f65a81"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "defmt 1.0.1",
+ "embedded-io-async 0.7.0",
+ "futures-core",
+ "futures-sink",
+ "heapless 0.9.2",
+]
+
+[[package]]
+name = "embassy-time"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592b0c143ec626e821d4d90da51a2bd91d559d6c442b7c74a47d368c9e23d97a"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -423,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-time-driver"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a244c7dc22c8d0289379c8d8830cae06bb93d8f990194d0de5efb3b5ae7ba6"
+checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
 dependencies = [
  "document-features",
 ]
@@ -558,8 +706,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "esp-alloc"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641e43d6a60244429117ef2fa7a47182120c7561336ea01f6fb08d634f46bae1"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "allocator-api2",
  "cfg-if",
@@ -575,8 +722,7 @@ dependencies = [
 [[package]]
 name = "esp-bootloader-esp-idf"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a56964ab5479ac20c9cf76fa3b0d3f2233b20b5d8554e81ef5d65f63c20567"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -592,8 +738,7 @@ dependencies = [
 [[package]]
 name = "esp-config"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102871054f8dd98202177b9890cb4b71d0c6fe1f1413b7a379a8e0841fc2473c"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
@@ -605,8 +750,7 @@ dependencies = [
 [[package]]
 name = "esp-hal"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54786287c0a61ca0f78cb0c338a39427551d1be229103b4444591796c579e093"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -619,7 +763,7 @@ dependencies = [
  "document-features",
  "embassy-embedded-hal",
  "embassy-futures",
- "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
  "embedded-can",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -637,7 +781,9 @@ dependencies = [
  "esp32",
  "esp32c2",
  "esp32c3",
+ "esp32c5",
  "esp32c6",
+ "esp32c61",
  "esp32h2",
  "esp32s2",
  "esp32s3",
@@ -646,6 +792,7 @@ dependencies = [
  "nb 1.1.0",
  "paste",
  "portable-atomic",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "rand_core 0.9.3",
  "riscv",
@@ -658,8 +805,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e025a7a7a0affdb4ff913b5c4494aef96ee03d085bf83c27453ae3a71d50da6"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "document-features",
  "proc-macro-crate",
@@ -672,36 +818,37 @@ dependencies = [
 [[package]]
 name = "esp-metadata-generated"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a93e39c8ad8d390d248dc7b9f4b59a873f313bf535218b8e2351356972399e3"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 
 [[package]]
 name = "esp-phy"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1facf348e1e251517278fc0f5dc134e95e518251f5796cfbb532ca226a29bf"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",
  "document-features",
+ "embassy-sync 0.8.0",
  "esp-config",
  "esp-hal",
  "esp-metadata-generated",
  "esp-sync",
- "esp-wifi-sys",
+ "esp-wifi-sys-esp32c3",
+ "esp32c3",
 ]
 
 [[package]]
 name = "esp-radio"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684c4de2f8907b73c9b891fbda65286a86d34fced4b856f36a7896c211f2f265"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "allocator-api2",
  "bt-hci",
  "cfg-if",
  "defmt 1.0.1",
+ "docsplay",
  "document-features",
+ "embassy-sync 0.8.0",
  "embedded-io 0.6.1",
  "embedded-io 0.7.1",
  "embedded-io-async 0.6.1",
@@ -715,27 +862,37 @@ dependencies = [
  "esp-phy",
  "esp-radio-rtos-driver",
  "esp-sync",
- "esp-wifi-sys",
+ "esp-wifi-sys-esp32",
+ "esp-wifi-sys-esp32c2",
+ "esp-wifi-sys-esp32c3",
+ "esp-wifi-sys-esp32c6",
+ "esp-wifi-sys-esp32h2",
+ "esp-wifi-sys-esp32s2",
+ "esp-wifi-sys-esp32s3",
+ "esp32c3",
  "heapless 0.9.2",
+ "ieee802154",
  "instability",
  "num-derive",
  "num-traits",
  "portable-atomic",
  "portable_atomic_enum",
- "smoltcp",
 ]
 
 [[package]]
 name = "esp-radio-rtos-driver"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543bc31d1851afd062357e7810c1a9633f282fd3993583499a841ab497cbca6c"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
+dependencies = [
+ "cfg-if",
+ "esp-sync",
+ "portable-atomic",
+]
 
 [[package]]
 name = "esp-riscv-rt"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502744a5b1e7268d27fd2a4e56ad45efe42ead517d6c517a6961540de949b0ee"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "defmt 1.0.1",
  "document-features",
@@ -746,26 +903,25 @@ dependencies = [
 [[package]]
 name = "esp-rom-sys"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd66cccc6dd2d13e9f33668a57717ab14a6d217180ec112e6be533de93e7ecbf"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "cfg-if",
  "document-features",
  "esp-metadata-generated",
+ "esp32c3",
 ]
 
 [[package]]
 name = "esp-rtos"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ec711c8d06e79c67b75d01595539e86b0aac209643af98ca87a12250428b3"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "allocator-api2",
  "cfg-if",
  "defmt 1.0.1",
  "document-features",
  "embassy-executor",
- "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
  "embassy-time-driver",
  "embassy-time-queue-utils",
  "esp-alloc",
@@ -774,15 +930,17 @@ dependencies = [
  "esp-hal-procmacros",
  "esp-metadata-generated",
  "esp-radio-rtos-driver",
+ "esp-rom-sys",
  "esp-sync",
  "portable-atomic",
+ "riscv",
+ "xtensa-lx",
 ]
 
 [[package]]
 name = "esp-storage"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1495fc1f5549bdd840b52d9ceb201746200e1620d2636f46958c11e765623b80"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "defmt 1.0.1",
  "document-features",
@@ -797,34 +955,87 @@ dependencies = [
 [[package]]
 name = "esp-sync"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44974639b4e88914f83fe60d2832c00276657d7d857628fdfc966cc7302e8a8"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",
  "document-features",
  "embassy-sync 0.6.2",
  "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
  "esp-metadata-generated",
  "riscv",
  "xtensa-lx",
 ]
 
 [[package]]
-name = "esp-wifi-sys"
-version = "0.8.1"
+name = "esp-wifi-sys-esp32"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b6544f6f0cb86169d1f93ba2101a8d50358a040c5043676ed86b793e09b12c"
+checksum = "2556f38f5292d9735d4e156e276815fc001c9a0a2be0544a575c5fb867129d24"
 dependencies = [
- "anyhow",
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32c2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b3eb3435dae84de611d4384639e61eed862818223e93fa70c525cb6a70127f"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32c3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b290846b53db9a3965866964260220b67f2c41cc2dbc0b377e7136239fe168a7"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32c6"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57649401fc2f906a16e2268de88693724a125adcd0eba89b594a157affcee2d5"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32h2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf1be2e311f4b4e75b5507c6b007ffc3fcb8c6cb57f83cc6a9569ecdcf58484"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32s2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a9a7f1bc51e7026c3012cda4f11d8799e5e0c0bb3be85797462219def6c26e"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32s3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8321f44b57d8112cbd8607cc83b85783b9195289acb45532728e3e229e7786"
+dependencies = [
  "defmt 1.0.1",
 ]
 
 [[package]]
 name = "esp32"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b76170a463d18f888a1ad258031901036fd827a9ef126733053ba5f8739fb0c8"
+checksum = "ea414047c2efb3bbc5e394dd1fe09016d27db92b4fbf2fc9a00b6b813de27884"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -833,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c2"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62cf8932966b8d445b6f1832977b468178f0a84effb2e9fda89f60c24d45aa3"
+checksum = "9fad8c1395fc135f86c67e0b2052304e7575602f17af542c1ba67110e819fb5a"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -844,9 +1055,20 @@ dependencies = [
 
 [[package]]
 name = "esp32c3"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356af3771d0d6536c735bf71136594f4d1cbb506abf6e0c51a6639e9bf4e7988"
+checksum = "5e8d61ef69888501c679b7ec42cd6d79d1e0d210d96c929ecc100fffdc02f3eb"
+dependencies = [
+ "critical-section",
+ "defmt 1.0.1",
+ "vcell",
+]
+
+[[package]]
+name = "esp32c5"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa2f7fc6e2be17c362ecad32a4eb9b2d2ec9ea6a23cd08fcb93e8984369ad222"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -855,9 +1077,20 @@ dependencies = [
 
 [[package]]
 name = "esp32c6"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5e511df672d79cd63365c92045135e01ba952b6bddd25b660baff5e1110f6b"
+checksum = "0ad5c007b1bc73bc1ff1c076abd67770cfa0a364553abe3c0c4d62a3e0645d02"
+dependencies = [
+ "critical-section",
+ "defmt 1.0.1",
+ "vcell",
+]
+
+[[package]]
+name = "esp32c61"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e18d316b49ea47baa7004d729cc90f4a0ab53828762f6bfc296a04e816c0c2"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -866,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "esp32h2"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4a50bbd1380931e095e0973b9b12f782a9c481f2edf1f7c42e7eb4ff736d6d"
+checksum = "f45a76fec7d2c3ee1213f89e66ade3d0f368ea7d45f88203e91bfe1fe4ec9c75"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -877,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "esp32s2"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98574d4c577fbe888fe3e6df7fc80d25a05624d9998f7d7de1500ae21fcca78f"
+checksum = "e4b09e7c54ac8c902203433ad9b1d3cd4b477a4fe669befdd9714dcef5d269d1"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
@@ -888,14 +1121,20 @@ dependencies = [
 
 [[package]]
 name = "esp32s3"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1810d8ee4845ef87542af981e38eb80ab531d0ef1061e1486014ab7af74c337a"
+checksum = "4519c25f8442f92d51feccc7bb87981b2a2a3c4b0ff512845b39fbdddd95d9bc"
 dependencies = [
  "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -991,6 +1230,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,11 +1256,31 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "hash32-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59d2aba832b60be25c1b169146b27c64115470981b128ed84c8db18c1b03c6ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1021,8 +1295,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "defmt 0.3.100",
- "hash32",
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -1033,7 +1306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
  "defmt 1.0.1",
- "hash32",
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -1048,6 +1321,20 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "ieee802154"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb6de62f20180795db19ae2ab338852a66f8576581554fa8a730e437b450a5"
+dependencies = [
+ "byte",
+ "ccm",
+ "cipher",
+ "defmt 0.3.100",
+ "hash32 0.2.1",
+ "hash32-derive",
+]
 
 [[package]]
 name = "indexmap"
@@ -1070,11 +1357,11 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -1122,6 +1409,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,10 +1448,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "managed"
-version = "0.8.0"
+name = "loom"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -1180,6 +1489,15 @@ name = "nb"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "num-derive"
@@ -1335,6 +1653,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "riscv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1772,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,18 +1827,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "smoltcp"
-version = "0.12.0"
+name = "sharded-slab"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "cfg-if",
- "defmt 0.3.100",
- "heapless 0.8.0",
- "managed",
+ "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "somni-expr"
@@ -1549,6 +1903,12 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svgbobdoc"
@@ -1615,6 +1975,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,17 +2014,78 @@ dependencies = [
 ]
 
 [[package]]
-name = "trouble-host"
-version = "0.5.1"
+name = "tracing"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2881b4859001fe1f48445145cda5149deac9110b1d707ec0a251b7ff6d8bdfa4"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "trouble-host"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df7817cead4b83dfbeeaa59736ecbc97c30b21dc3bfc0cc2ce8a6687f70b37a"
 dependencies = [
  "bt-hci",
  "defmt 1.0.1",
  "embassy-futures",
  "embassy-sync 0.7.2",
  "embassy-time",
- "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
  "futures",
  "heapless 0.9.2",
  "rand_core 0.6.4",
@@ -1666,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "trouble-host-macros"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb85bec3a8393c22ca1a7c25c82c2d33689ab412f3487c492fd01a033ede7c2"
+checksum = "2d809ae05f510cf8f1d863749281eb28e049d9ae4ad52d92ea7a0ac068a0e17c"
 dependencies = [
  "convert_case",
  "darling 0.20.11",
@@ -1723,6 +2153,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcell"
@@ -1803,6 +2239,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,8 +2268,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e012d667b0aa6d2592ace8ef145a98bff3e76cca7a644f4181ecd7a916ed289b"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "critical-section",
 ]
@@ -1832,8 +2276,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8709f037fb123fe7ff146d2bce86f9dc0dfc53045c016bfd9d703317b6502845"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "defmt 1.0.1",
  "document-features",
@@ -1844,8 +2287,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fb42cd29c42f8744c74276e9f5bee7b06685bbe5b88df891516d72cb320450"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=c670420#c670420d04a172ff185fb5d2b901d2cb63757ee5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,7 @@ embedded-hal = "1.0.0"
 embedded-storage = "0.3.1"
 esp-alloc = { version = "0.10.0", features = ["defmt"] }
 esp-bootloader-esp-idf = { version = "0.5.0", features = ["esp32c3"] }
-esp-hal = { version = "1.1.0-rc.0", features = [
-    "defmt",
-    "esp32c3",
-    "unstable",
-] }
+esp-hal = { version = "1.1.0", features = ["defmt", "esp32c3", "unstable"] }
 esp-radio = { version = "0.18.0", features = [
     "ble",
     "defmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,13 @@ version = "0.3.1"
 
 [dependencies]
 arrayvec = { version = "0.7.6", default-features = false }
-bt-hci = { version = "0.6.0", features = ["defmt"] }
+bt-hci = { version = "0.8.0", features = ["defmt"] }
 critical-section = "1.2.0"
 defmt = "1.0.1"
-embassy-executor = { version = "0.9.1", features = ["defmt"] }
+embassy-executor = { version = "0.10.0", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", features = ["defmt"] }
 embassy-sync = { version = "0.7.2", features = ["defmt"] }
-embassy-time = { version = "0.5.0", features = ["defmt"] }
+embassy-time = { version = "0.5.1", features = ["defmt"] }
 embedded-hal = "1.0.0"
 embedded-storage = "0.3.1"
 esp-alloc = { version = "0.9.0", features = ["defmt"] }
@@ -38,7 +38,7 @@ esp-storage = { version = "0.8.1", features = ["defmt", "esp32c3"] }
 panic-rtt-target = { version = "0.2.0", features = ["defmt"] }
 rtt-target = { version = "0.6.2", features = ["defmt"] }
 static_cell = "2.1.1"
-trouble-host = { version = "0.5.1", features = ["defmt"] }
+trouble-host = { version = "0.6.0", features = ["defmt"] }
 
 [profile.dev]
 # Rust debug is too slow.
@@ -53,3 +53,11 @@ incremental      = false
 lto              = 'fat'
 opt-level        = 's'
 overflow-checks  = false
+
+[patch.crates-io]
+esp-alloc              = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c670420", package = "esp-alloc" }
+esp-bootloader-esp-idf = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c670420", package = "esp-bootloader-esp-idf" }
+esp-hal                = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c670420", package = "esp-hal" }
+esp-radio              = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c670420", package = "esp-radio" }
+esp-rtos               = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c670420", package = "esp-rtos" }
+esp-storage            = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c670420", package = "esp-storage" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,25 +16,28 @@ embassy-sync = { version = "0.7.2", features = ["defmt"] }
 embassy-time = { version = "0.5.1", features = ["defmt"] }
 embedded-hal = "1.0.0"
 embedded-storage = "0.3.1"
-esp-alloc = { version = "0.9.0", features = ["defmt"] }
-esp-bootloader-esp-idf = { version = "0.4.0", features = ["esp32c3"] }
-esp-hal = { version = "1.0.0", features = ["defmt", "esp32c3", "unstable"] }
-esp-radio = { version = "0.17.0", features = [
+esp-alloc = { version = "0.10.0", features = ["defmt"] }
+esp-bootloader-esp-idf = { version = "0.5.0", features = ["esp32c3"] }
+esp-hal = { version = "1.1.0-rc.0", features = [
+    "defmt",
+    "esp32c3",
+    "unstable",
+] }
+esp-radio = { version = "0.18.0", features = [
     "ble",
     "defmt",
     "esp-alloc",
     "esp32c3",
     "unstable",
 ] }
-esp-rtos = { version = "0.2.0", features = [
+esp-rtos = { version = "0.3.0", features = [
     "defmt",
     "embassy",
     "esp-alloc",
     "esp-radio",
     "esp32c3",
-
 ] }
-esp-storage = { version = "0.8.1", features = ["defmt", "esp32c3"] }
+esp-storage = { version = "0.9.0", features = ["defmt", "esp32c3"] }
 panic-rtt-target = { version = "0.2.0", features = ["defmt"] }
 rtt-target = { version = "0.6.2", features = ["defmt"] }
 static_cell = "2.1.1"
@@ -53,11 +56,3 @@ incremental      = false
 lto              = 'fat'
 opt-level        = 's'
 overflow-checks  = false
-
-[patch.crates-io]
-esp-alloc              = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c670420", package = "esp-alloc" }
-esp-bootloader-esp-idf = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c670420", package = "esp-bootloader-esp-idf" }
-esp-hal                = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c670420", package = "esp-hal" }
-esp-radio              = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c670420", package = "esp-radio" }
-esp-rtos               = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c670420", package = "esp-rtos" }
-esp-storage            = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c670420", package = "esp-storage" }

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -6,7 +6,7 @@ use arrayvec::ArrayVec;
 use defmt::{debug, info};
 use trouble_host::prelude::*;
 
-use crate::progressor::{DataPoint, MAX_PAYLOAD_SIZE};
+use crate::progressor::{CONTROL_POINT_MAX_PAYLOAD_SIZE, DataPoint};
 
 /// Max number of connections
 pub const CONNECTIONS_MAX: usize = 1;
@@ -62,7 +62,7 @@ pub struct ProgressorService {
         write,
         write_without_response
     )]
-    pub control_point: [u8; MAX_PAYLOAD_SIZE], // Buffer for command data
+    pub control_point: [u8; CONTROL_POINT_MAX_PAYLOAD_SIZE],
 }
 
 /// Create an advertiser to use to connect to a BLE Central, and wait for it to connect.

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -1,7 +1,8 @@
-/// BLE module
-///
-/// This module provides the BLE functionality for the Progressor.
-/// It includes the BLE advertising data, the GATT server, and the BLE connection.
+//! BLE module
+//!
+//! This module provides the BLE functionality for the Progressor.
+//! It includes the BLE advertising data, the GATT server, and the BLE connection.
+#![allow(clippy::needless_borrows_for_generic_args)]
 use arrayvec::ArrayVec;
 use defmt::{debug, info};
 use trouble_host::prelude::*;

--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -245,6 +245,20 @@ impl<'d> Hx711<'d> {
         Ok(())
     }
 
+    /// Put the HX711 into its low-power power-down mode.
+    pub fn power_down(&mut self) {
+        debug!("Powering down HX711");
+        self.clock.set_high();
+        self.delay.delay_us(80);
+    }
+
+    /// Wake the HX711 back up after power-down.
+    pub fn power_up(&mut self) {
+        debug!("Powering up HX711");
+        self.clock.set_low();
+        self.delay.delay_us(80);
+    }
+
     /// Reads a single bit from the data pin.
     #[inline]
     fn read_data_bit(&mut self) -> bool {

--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -42,7 +42,7 @@ const DEFAULT_TARING_SAMPLES: usize = 16;
 /// The default number of samples for calibration
 const DEFAULT_CALIBRATION_SAMPLES: usize = 100;
 /// The default calibration value.
-const DEFAULT_CALIBRATION_FACTOR: f32 = 0.0639;
+const DEFAULT_CALIBRATION_FACTOR: f32 = 0.08;
 
 /// Custom error type for HX711 operations
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use esp_hal::{
 use esp_radio::ble::controller::BleConnector;
 use esp_storage::FlashStorage;
 use panic_rtt_target as _;
-use static_cell::StaticCell;
+// use static_cell::StaticCell;
 use trouble_host::prelude::*;
 
 use crate::{
@@ -88,13 +88,9 @@ async fn main(spawner: Spawner) -> ! {
     let sw_interrupt = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
     esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
 
-    // Initialize radio
-    static RADIO: StaticCell<esp_radio::Controller<'static>> = StaticCell::new();
-    let radio = RADIO.init(esp_radio::init().unwrap());
-
     // Initialize BLE
     let bluetooth = peripherals.BT;
-    let connector = BleConnector::new(radio, bluetooth, Default::default()).unwrap();
+    let connector = BleConnector::new(bluetooth, Default::default()).unwrap();
     let controller: ExternalController<_, 1> = ExternalController::new(connector);
 
     // Initialize load cell pins
@@ -159,13 +155,9 @@ async fn main(spawner: Spawner) -> ! {
     });
 
     // Spawn tasks
-    spawner
-        .spawn(measurement_task(channel, clock_pin, data_pin, delay, flash))
-        .unwrap();
-    spawner
-        .spawn(battery_voltage_task(battery_adc, battery_pin))
-        .unwrap();
-    spawner.spawn(deep_sleep_task(rtc)).unwrap();
+    spawner.spawn(measurement_task(channel, clock_pin, data_pin, delay, flash).unwrap());
+    spawner.spawn(battery_voltage_task(battery_adc, battery_pin).unwrap());
+    spawner.spawn(deep_sleep_task(rtc).unwrap());
 
     let _ = join(ble_task(runner), async {
         loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -366,10 +366,11 @@ async fn measurement_task(
         match status {
             MeasurementTaskStatus::Disabled => {
                 if !measurement_buffer.is_empty() {
-                    crate::progressor::DataPoint::weight_measurement(measurement_buffer.clone())
-                        .send(channel)
-                        .await;
-                    measurement_buffer.clear();
+                    crate::progressor::DataPoint::weight_measurement(core::mem::take(
+                        &mut measurement_buffer,
+                    ))
+                    .send(channel)
+                    .await;
                 }
             }
             MeasurementTaskStatus::Tare => {
@@ -398,10 +399,11 @@ async fn measurement_task(
                 let timestamp = now.wrapping_sub(start_time);
                 measurement_buffer.push((weight, timestamp));
                 if measurement_buffer.is_full() {
-                    crate::progressor::DataPoint::weight_measurement(measurement_buffer.clone())
-                        .send(channel)
-                        .await;
-                    measurement_buffer.clear();
+                    crate::progressor::DataPoint::weight_measurement(core::mem::take(
+                        &mut measurement_buffer,
+                    ))
+                    .send(channel)
+                    .await;
                 }
             }
             MeasurementTaskStatus::Calibration(weight) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,9 @@ async fn main(spawner: Spawner) -> ! {
 
     // Initialize BLE
     let bluetooth = peripherals.BT;
-    let connector = BleConnector::new(bluetooth, Default::default()).unwrap();
+    let ble_config = esp_radio::ble::Config::default()
+        .with_default_tx_power(esp_radio::ble::TxPower::P20);
+    let connector = BleConnector::new(bluetooth, ble_config).unwrap();
     let controller: ExternalController<_, 1> = ExternalController::new(connector);
 
     // Initialize load cell pins
@@ -164,6 +166,18 @@ async fn main(spawner: Spawner) -> ! {
             match advertise(device_name, &mut peripheral, &server).await {
                 Ok(conn) => {
                     info!("BLE connection established");
+
+                    let params = trouble_host::prelude::RequestedConnParams {
+                        min_connection_interval: Duration::from_millis(15),
+                        max_connection_interval: Duration::from_millis(45),
+                        max_latency: 0,
+                        min_event_length: Duration::from_millis(0),
+                        max_event_length: Duration::from_millis(0),
+                        supervision_timeout: Duration::from_millis(4000),
+                    };
+                    if let Err(e) = conn.raw().update_connection_params(&stack, &params).await {
+                        warn!("Failed to request connection params: {:?}", defmt::Debug2Format(&e));
+                    }
                     channel.clear();
                     critical_section::with(|cs| {
                         DEVICE_STATE.borrow_ref_mut(cs).on_ble_connected();

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,8 @@ use crate::{
         MAX_CALIBRATION_POINTS,
         MeasurementTaskStatus,
         ResponseCode,
+        SleepReason,
+        SleepState,
         WeightMeasurementBatch,
     },
 };
@@ -65,7 +67,9 @@ static DEVICE_STATE: Mutex<RefCell<DeviceState>> = Mutex::new(RefCell::new(Devic
     calibration_points: [(0.0, 0.0); MAX_CALIBRATION_POINTS],
     calibration_point_count: 0,
     battery_voltage: 4300,
-    ble_disconnection_time: None,
+    last_activity_time_ms: 0,
+    ble_connected: false,
+    sleep_state: SleepState::Awake,
 }));
 
 // ESP-IDF App Descriptor
@@ -151,7 +155,7 @@ async fn main(spawner: Spawner) -> ! {
     // Data point channel for communication between tasks
     let channel = mk_static!(DataPointChannel, Channel::new());
 
-    // Start idle timer: if no BLE connection happens within TIMEOUT_MS, deep_sleep_task will sleep.
+    // Start inactivity tracking from boot so the device can auto-sleep if left unused.
     critical_section::with(|cs| {
         DEVICE_STATE.borrow_ref_mut(cs).on_ble_disconnected();
     });
@@ -198,10 +202,7 @@ async fn main(spawner: Spawner) -> ! {
                         let mut state = DEVICE_STATE.borrow_ref_mut(cs);
                         state.stop_measurement();
                         state.on_ble_disconnected();
-                        debug!(
-                            "BLE connection closed, disconnection time: {:?}",
-                            state.ble_disconnection_time
-                        );
+                        debug!("BLE connection closed, inactivity timer restarted");
                     });
                 }
                 Err(e) => {
@@ -228,28 +229,50 @@ async fn ble_task<C: Controller, P: PacketPool>(mut runner: Runner<'_, C, P>) {
 
 #[embassy_executor::task]
 async fn deep_sleep_task(mut rtc: Rtc<'static>) {
-    const TIMEOUT_MS: u32 = 5 * 60 * 1000; // 5 minutes
+    const IDLE_TIMEOUT_MS: u32 = 4 * 60 * 1000; // 4 minutes
 
     loop {
-        let elapsed_ms = critical_section::with(|cs| {
-            DEVICE_STATE
-                .borrow_ref(cs)
-                .get_ble_disconnection_elapsed_ms()
-        });
+        let (sleep_state, measurement_status, inactivity_ms, ble_connected) =
+            critical_section::with(|cs| {
+                let state = DEVICE_STATE.borrow_ref(cs);
+                (
+                    state.sleep_state,
+                    state.measurement_status,
+                    state.get_inactivity_elapsed_ms(),
+                    state.is_ble_connected(),
+                )
+            });
 
-        if let Some(elapsed) = elapsed_ms {
-            debug!("BLE disconnected for {:?} ms", elapsed);
+        match sleep_state {
+            SleepState::Awake => {
+                if measurement_status == MeasurementTaskStatus::Disabled {
+                    debug!(
+                        "Device idle for {:?} ms (connected: {}, timeout: {:?} ms)",
+                        inactivity_ms,
+                        ble_connected,
+                        IDLE_TIMEOUT_MS
+                    );
 
-            if elapsed >= TIMEOUT_MS {
-                info!(
-                    "Entering deep sleep after {} minutes of BLE disconnection",
-                    TIMEOUT_MS / 60000
-                );
-                Timer::after(Duration::from_millis(10)).await;
+                    if inactivity_ms >= IDLE_TIMEOUT_MS {
+                        critical_section::with(|cs| {
+                            DEVICE_STATE
+                                .borrow_ref_mut(cs)
+                                .request_sleep(SleepReason::IdleTimeout);
+                        });
+                    }
+                }
+            }
+            SleepState::Requested(reason) => {
+                debug!("Waiting for peripherals to power down before sleep: {:?}", reason);
+            }
+            SleepState::Ready(reason) => {
+                info!("Entering deep sleep: {:?}", reason);
+                Timer::after(Duration::from_millis(20)).await;
                 rtc.sleep_deep(&[]);
             }
         }
-        Timer::after(Duration::from_secs(10)).await;
+
+        Timer::after(Duration::from_secs(1)).await;
     }
 }
 
@@ -300,13 +323,41 @@ async fn measurement_task(
         error!("Initial tare failed: {:?}", defmt::Debug2Format(&e));
     }
     let mut measurement_buffer = WeightMeasurementBatch::new();
+    let mut hx711_powered_down = false;
 
     loop {
         // Get current device state
-        let (status, start_time) = critical_section::with(|cs| {
+        let (sleep_state, status, start_time) = critical_section::with(|cs| {
             let state = DEVICE_STATE.borrow_ref(cs);
-            (state.measurement_status, state.start_time)
+            (state.sleep_state, state.measurement_status, state.start_time)
         });
+
+        if hx711_powered_down && sleep_state == SleepState::Awake {
+            info!("Waking HX711 after sleep request was cancelled");
+            load_cell.power_up();
+            hx711_powered_down = false;
+        }
+
+        match sleep_state {
+            SleepState::Requested(reason) => {
+                if !hx711_powered_down {
+                    info!("Powering down HX711 before deep sleep: {:?}", reason);
+                    measurement_buffer.clear();
+                    load_cell.power_down();
+                    hx711_powered_down = true;
+                    critical_section::with(|cs| {
+                        DEVICE_STATE.borrow_ref_mut(cs).mark_sleep_ready();
+                    });
+                }
+                Timer::after(Duration::from_millis(20)).await;
+                continue;
+            }
+            SleepState::Ready(_) => {
+                Timer::after(Duration::from_millis(50)).await;
+                continue;
+            }
+            SleepState::Awake => {}
+        }
 
         match status {
             MeasurementTaskStatus::Disabled => {
@@ -519,15 +570,24 @@ async fn gatt_events_task<P: PacketPool>(
                                 info!("Control Point Received: {:?}", op_code);
                                 critical_section::with(|cs| {
                                     let mut device_state = DEVICE_STATE.borrow_ref_mut(cs);
+                                    if op_code.counts_as_activity() {
+                                        device_state.record_activity();
+                                    }
                                     op_code.process(cmd_data, &mut device_state)
                                 })
                             }
                             Err(()) => {
+                                critical_section::with(|cs| {
+                                    DEVICE_STATE.borrow_ref_mut(cs).record_activity();
+                                });
                                 warn!("Ignoring unsupported OpCode: {:#x}", op_code_byte);
                                 None
                             }
                         },
                         None => {
+                            critical_section::with(|cs| {
+                                DEVICE_STATE.borrow_ref_mut(cs).record_activity();
+                            });
                             warn!("Control Point write with empty payload");
                             None
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,6 @@ use esp_hal::{
     interrupt::software::SoftwareInterruptControl,
     peripherals,
     rtc_cntl::Rtc,
-    time,
     timer::timg::TimerGroup,
 };
 use esp_radio::ble::controller::BleConnector;
@@ -41,6 +40,7 @@ use crate::{
         MAX_CALIBRATION_POINTS,
         MeasurementTaskStatus,
         ResponseCode,
+        WeightMeasurementBatch,
     },
 };
 
@@ -90,8 +90,8 @@ async fn main(spawner: Spawner) -> ! {
 
     // Initialize BLE
     let bluetooth = peripherals.BT;
-    let ble_config = esp_radio::ble::Config::default()
-        .with_default_tx_power(esp_radio::ble::TxPower::P20);
+    let ble_config =
+        esp_radio::ble::Config::default().with_default_tx_power(esp_radio::ble::TxPower::P20);
     let connector = BleConnector::new(bluetooth, ble_config).unwrap();
     let controller: ExternalController<_, 1> = ExternalController::new(connector);
 
@@ -176,8 +176,12 @@ async fn main(spawner: Spawner) -> ! {
                         supervision_timeout: Duration::from_millis(4000),
                     };
                     if let Err(e) = conn.raw().update_connection_params(&stack, &params).await {
-                        warn!("Failed to request connection params: {:?}", defmt::Debug2Format(&e));
+                        warn!(
+                            "Failed to request connection params: {:?}",
+                            defmt::Debug2Format(&e)
+                        );
                     }
+
                     channel.clear();
                     critical_section::with(|cs| {
                         DEVICE_STATE.borrow_ref_mut(cs).on_ble_connected();
@@ -295,6 +299,7 @@ async fn measurement_task(
     if let Err(e) = load_cell.tare().await {
         error!("Initial tare failed: {:?}", defmt::Debug2Format(&e));
     }
+    let mut measurement_buffer = WeightMeasurementBatch::new();
 
     loop {
         // Get current device state
@@ -305,7 +310,12 @@ async fn measurement_task(
 
         match status {
             MeasurementTaskStatus::Disabled => {
-                // Do nothing when disabled
+                if !measurement_buffer.is_empty() {
+                    crate::progressor::DataPoint::weight_measurement(measurement_buffer.clone())
+                        .send(channel)
+                        .await;
+                    measurement_buffer.clear();
+                }
             }
             MeasurementTaskStatus::Tare => {
                 // Perform taring operation
@@ -319,7 +329,25 @@ async fn measurement_task(
                 });
             }
             MeasurementTaskStatus::Enabled => {
-                send_weight_measurement(&mut load_cell, start_time, channel).await;
+                let weight = match load_cell.read_calibrated().await {
+                    Ok(weight) => weight,
+                    Err(e) => {
+                        error!(
+                            "Failed to read weight measurement: {:?}",
+                            defmt::Debug2Format(&e)
+                        );
+                        continue;
+                    }
+                };
+                let now = (esp_hal::time::Instant::now().duration_since_epoch()).as_micros() as u32;
+                let timestamp = now.wrapping_sub(start_time);
+                measurement_buffer.push((weight, timestamp));
+                if measurement_buffer.is_full() {
+                    crate::progressor::DataPoint::weight_measurement(measurement_buffer.clone())
+                        .send(channel)
+                        .await;
+                    measurement_buffer.clear();
+                }
             }
             MeasurementTaskStatus::Calibration(weight) => {
                 if !weight.is_finite() || weight < 0.0 {
@@ -445,36 +473,6 @@ async fn measurement_task(
     }
 }
 
-/// Send a weight measurement data point with current timestamp
-async fn send_weight_measurement(
-    load_cell: &mut Hx711<'_>,
-    start_time: u32,
-    channel: &'static DataPointChannel,
-) {
-    let weight = match load_cell.read_calibrated().await {
-        Ok(weight) => weight,
-        Err(e) => {
-            error!(
-                "Failed to read weight measurement: {:?}",
-                defmt::Debug2Format(&e)
-            );
-            return;
-        }
-    };
-    let now = (time::Instant::now().duration_since_epoch()).as_micros() as u32;
-    let timestamp = now.wrapping_sub(start_time);
-
-    debug!(
-        "Sending measurement: Weight: {}kg, Timestamp: {:?}",
-        weight,
-        timestamp as f32 / 1000000.0
-    );
-
-    DataPoint::weight_measurement(weight, timestamp)
-        .send(channel)
-        .await;
-}
-
 async fn notify_calibration_points(
     channel: &'static DataPointChannel,
     calibration_points: &[CalibrationPoint],
@@ -568,7 +566,7 @@ async fn data_processing_task<P: PacketPool>(
     conn: &GattConnection<'_, '_, P>,
     channel: &'static DataPointChannel,
 ) {
-    let data_point_handle = server.progressor.data_point;
+    let data_point_handle = &server.progressor.data_point;
 
     loop {
         let data_point = channel.receive().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,6 @@ use esp_hal::{
 use esp_radio::ble::controller::BleConnector;
 use esp_storage::FlashStorage;
 use panic_rtt_target as _;
-// use static_cell::StaticCell;
 use trouble_host::prelude::*;
 
 use crate::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,9 +248,7 @@ async fn deep_sleep_task(mut rtc: Rtc<'static>) {
                 if measurement_status == MeasurementTaskStatus::Disabled {
                     debug!(
                         "Device idle for {:?} ms (connected: {}, timeout: {:?} ms)",
-                        inactivity_ms,
-                        ble_connected,
-                        IDLE_TIMEOUT_MS
+                        inactivity_ms, ble_connected, IDLE_TIMEOUT_MS
                     );
 
                     if inactivity_ms >= IDLE_TIMEOUT_MS {
@@ -263,7 +261,10 @@ async fn deep_sleep_task(mut rtc: Rtc<'static>) {
                 }
             }
             SleepState::Requested(reason) => {
-                debug!("Waiting for peripherals to power down before sleep: {:?}", reason);
+                debug!(
+                    "Waiting for peripherals to power down before sleep: {:?}",
+                    reason
+                );
             }
             SleepState::Ready(reason) => {
                 info!("Entering deep sleep: {:?}", reason);
@@ -329,7 +330,11 @@ async fn measurement_task(
         // Get current device state
         let (sleep_state, status, start_time) = critical_section::with(|cs| {
             let state = DEVICE_STATE.borrow_ref(cs);
-            (state.sleep_state, state.measurement_status, state.start_time)
+            (
+                state.sleep_state,
+                state.measurement_status,
+                state.start_time,
+            )
         });
 
         if hx711_powered_down && sleep_state == SleepState::Awake {

--- a/src/progressor.rs
+++ b/src/progressor.rs
@@ -49,6 +49,26 @@ pub enum MeasurementTaskStatus {
     GetCalibration,
 }
 
+/// Reason why the device is transitioning to sleep.
+#[derive(Copy, Clone, Debug, PartialEq, Format)]
+pub enum SleepReason {
+    /// No user or BLE activity has been observed for too long.
+    IdleTimeout,
+    /// The mobile app explicitly requested device shutdown.
+    ShutdownCommand,
+}
+
+/// Sleep transition state.
+#[derive(Copy, Clone, Debug, PartialEq, Format)]
+pub enum SleepState {
+    /// Device is fully awake.
+    Awake,
+    /// Deep sleep has been requested and peripherals are shutting down.
+    Requested(SleepReason),
+    /// Peripherals are powered down and deep sleep can be entered.
+    Ready(SleepReason),
+}
+
 /// Device state management
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeviceState {
@@ -62,8 +82,12 @@ pub struct DeviceState {
     pub calibration_point_count: usize,
     /// Battery voltage in millivolts
     pub battery_voltage: u32,
-    /// BLE disconnection time in milliseconds (None when connected)
-    pub ble_disconnection_time: Option<u32>,
+    /// Timestamp of the last user-visible activity.
+    pub last_activity_time_ms: u32,
+    /// Whether BLE is currently connected.
+    pub ble_connected: bool,
+    /// Current sleep transition state.
+    pub sleep_state: SleepState,
 }
 
 impl Default for DeviceState {
@@ -74,60 +98,105 @@ impl Default for DeviceState {
             calibration_points: [(0.0, 0.0); MAX_CALIBRATION_POINTS],
             calibration_point_count: 0,
             battery_voltage: 4300,
-            ble_disconnection_time: None,
+            last_activity_time_ms: 0,
+            ble_connected: false,
+            sleep_state: SleepState::Awake,
         }
     }
 }
 
 impl DeviceState {
+    fn now_ms() -> u32 {
+        (time::Instant::now().duration_since_epoch()).as_millis() as u32
+    }
+
+    fn cancel_idle_sleep_request(&mut self) {
+        match self.sleep_state {
+            SleepState::Requested(SleepReason::IdleTimeout)
+            | SleepState::Ready(SleepReason::IdleTimeout) => {
+                self.sleep_state = SleepState::Awake;
+            }
+            SleepState::Awake | SleepState::Requested(_) | SleepState::Ready(_) => {}
+        }
+    }
+
+    /// Record user-visible activity so idle sleep can be postponed.
+    pub fn record_activity(&mut self) {
+        self.cancel_idle_sleep_request();
+        self.last_activity_time_ms = Self::now_ms();
+    }
+
     /// Start a measurement
     pub fn start_measurement(&mut self) {
+        self.record_activity();
         self.start_time = (time::Instant::now().duration_since_epoch()).as_micros() as u32;
         self.measurement_status = MeasurementTaskStatus::Enabled;
     }
 
     /// Stop the current measurement
     pub fn stop_measurement(&mut self) {
+        self.record_activity();
         self.measurement_status = MeasurementTaskStatus::Disabled;
     }
 
     /// Start taring process
     pub fn tare(&mut self) {
+        self.record_activity();
         self.measurement_status = MeasurementTaskStatus::Tare;
     }
 
     /// Set calibration mode with the given weight
     pub fn calibrate(&mut self, weight: f32) {
+        self.record_activity();
         self.measurement_status = MeasurementTaskStatus::Calibration(weight);
     }
 
     pub fn get_calibration(&mut self) {
+        self.record_activity();
         self.measurement_status = MeasurementTaskStatus::GetCalibration;
     }
 
     /// Reset to default calibration
     pub fn reset_calibration(&mut self) {
+        self.record_activity();
         self.measurement_status = MeasurementTaskStatus::DefaultCalibration;
     }
 
-    /// Mark BLE as connected (clear disconnection time)
+    /// Mark BLE as connected.
     pub fn on_ble_connected(&mut self) {
-        self.ble_disconnection_time = None;
+        self.ble_connected = true;
+        self.record_activity();
     }
 
-    /// Mark BLE as disconnected (record current time)
+    /// Mark BLE as disconnected.
     pub fn on_ble_disconnected(&mut self) {
-        self.ble_disconnection_time =
-            Some((time::Instant::now().duration_since_epoch()).as_millis() as u32);
+        self.ble_connected = false;
+        self.record_activity();
     }
 
-    /// Get elapsed time since BLE disconnection in milliseconds
-    /// Returns None if BLE is currently connected
-    pub fn get_ble_disconnection_elapsed_ms(&self) -> Option<u32> {
-        self.ble_disconnection_time.map(|disconnect_time| {
-            let current_time = (time::Instant::now().duration_since_epoch()).as_millis() as u32;
-            current_time.saturating_sub(disconnect_time)
-        })
+    /// Returns true when BLE is currently connected.
+    pub fn is_ble_connected(&self) -> bool {
+        self.ble_connected
+    }
+
+    /// Get elapsed inactivity time in milliseconds.
+    pub fn get_inactivity_elapsed_ms(&self) -> u32 {
+        Self::now_ms().saturating_sub(self.last_activity_time_ms)
+    }
+
+    /// Request deep sleep. The measurement task will power down peripherals first.
+    pub fn request_sleep(&mut self, reason: SleepReason) {
+        if self.sleep_state == SleepState::Awake {
+            self.measurement_status = MeasurementTaskStatus::Disabled;
+            self.sleep_state = SleepState::Requested(reason);
+        }
+    }
+
+    /// Mark that peripherals are powered down and deep sleep can start.
+    pub fn mark_sleep_ready(&mut self) {
+        if let SleepState::Requested(reason) = self.sleep_state {
+            self.sleep_state = SleepState::Ready(reason);
+        }
     }
 }
 
@@ -177,6 +246,11 @@ pub enum ControlOpCode {
 }
 
 impl ControlOpCode {
+    /// Returns whether this command should reset the idle timer.
+    pub fn counts_as_activity(self) -> bool {
+        !matches!(self, ControlOpCode::SampleBattery)
+    }
+
     /// Process the control operation.
     ///
     /// Returns an immediate response packet when the command requires one.
@@ -262,9 +336,13 @@ impl ControlOpCode {
                 info!("SampleBattery: {:?}", response);
                 Some(DataPoint::from(response))
             }
+            ControlOpCode::Shutdown => {
+                info!("Shutdown command received");
+                device_state.request_sleep(SleepReason::ShutdownCommand);
+                None
+            }
             // Currently unimplemented operations
-            ControlOpCode::Shutdown
-            | ControlOpCode::StartPeakRFDMeasurement
+            ControlOpCode::StartPeakRFDMeasurement
             | ControlOpCode::StartPeakRFDMeasurementSeries
             | ControlOpCode::SaveCalibration
             | ControlOpCode::ClearErrorInformation

--- a/src/progressor.rs
+++ b/src/progressor.rs
@@ -13,8 +13,16 @@ const DATA_POINT_COMMAND_CHANNEL_SIZE: usize = 80;
 /// Channel used to send data points
 pub type DataPointChannel = Channel<NoopRawMutex, DataPoint, DATA_POINT_COMMAND_CHANNEL_SIZE>;
 
-/// Maximum size of the data payload in bytes for any data point
-pub const MAX_PAYLOAD_SIZE: usize = 10;
+/// Number of samples packed into each BLE measurement packet.
+pub const SAMPLES_PER_PACKET: usize = 5;
+/// Size in bytes of one packed weight measurement (f32 weight + u32 timestamp).
+const WEIGHT_MEASUREMENT_SIZE: usize = 8;
+/// Maximum size of the payload written to the Control Point characteristic.
+pub const CONTROL_POINT_MAX_PAYLOAD_SIZE: usize = 10;
+/// Batch of weight measurements sent in a single BLE packet.
+pub type WeightMeasurementBatch = arrayvec::ArrayVec<(f32, u32), SAMPLES_PER_PACKET>;
+/// Maximum size of the payload sent in a Data Point notification.
+pub const DATA_POINT_MAX_PAYLOAD_SIZE: usize = SAMPLES_PER_PACKET * WEIGHT_MEASUREMENT_SIZE;
 
 /// Number of bytes in the device ID
 const DEVICE_ID_SIZE: usize = 6;
@@ -318,7 +326,7 @@ impl Format for ControlOpCode {
 }
 
 /// Data point characteristic is where we receive data from the Progressor
-#[derive(Copy, Debug, Clone)]
+#[derive(Debug, Clone)]
 #[repr(C, packed)]
 pub struct DataPoint {
     /// Response code
@@ -326,15 +334,15 @@ pub struct DataPoint {
     /// Length of the data
     pub(crate) length: u8,
     /// Data
-    pub(crate) value: [u8; MAX_PAYLOAD_SIZE],
+    pub(crate) value: [u8; DATA_POINT_MAX_PAYLOAD_SIZE],
 }
 
 impl AsGatt for DataPoint {
     const MIN_SIZE: usize = 2;
-    const MAX_SIZE: usize = MAX_PAYLOAD_SIZE + 2; // +2 for response_code and length
+    const MAX_SIZE: usize = DATA_POINT_MAX_PAYLOAD_SIZE + 2; // +2 for response_code and length
 
     fn as_gatt(&self) -> &[u8] {
-        let len = (self.length as usize).min(MAX_PAYLOAD_SIZE);
+        let len = (self.length as usize).min(DATA_POINT_MAX_PAYLOAD_SIZE);
         unsafe { core::slice::from_raw_parts(self as *const DataPoint as *const u8, 2 + len) }
     }
 }
@@ -347,7 +355,7 @@ impl FromGatt for DataPoint {
 
         let response_code = data[0];
         let length = data[1] as usize;
-        if length > MAX_PAYLOAD_SIZE || data.len() != 2 + length {
+        if length > DATA_POINT_MAX_PAYLOAD_SIZE || data.len() != 2 + length {
             return Err(FromGattError::InvalidLength);
         }
 
@@ -360,7 +368,7 @@ impl Default for DataPoint {
         Self {
             response_code: 0,
             length: 0,
-            value: [0; MAX_PAYLOAD_SIZE],
+            value: [0; DATA_POINT_MAX_PAYLOAD_SIZE],
         }
     }
 }
@@ -368,8 +376,8 @@ impl Default for DataPoint {
 impl DataPoint {
     /// Create a new data point with specified response code, length and data
     pub fn new(response_code: u8, length: u8, data: &[u8]) -> Self {
-        let mut value = [0; MAX_PAYLOAD_SIZE];
-        let max_len = length.min(MAX_PAYLOAD_SIZE as u8) as usize;
+        let mut value = [0; DATA_POINT_MAX_PAYLOAD_SIZE];
+        let max_len = length.min(DATA_POINT_MAX_PAYLOAD_SIZE as u8) as usize;
         let copy_len = max_len.min(data.len());
         if copy_len > 0 {
             value[..copy_len].copy_from_slice(&data[..copy_len]);
@@ -388,14 +396,14 @@ impl DataPoint {
     }
 
     /// Create a weight measurement data point
-    pub fn weight_measurement(weight: f32, timestamp: u32) -> Self {
-        Self::from(ResponseCode::WeightMeasurement(weight, timestamp))
+    pub fn weight_measurement(measurements: WeightMeasurementBatch) -> Self {
+        Self::from(ResponseCode::WeightMeasurement(measurements))
     }
 }
 
 impl Format for DataPoint {
     fn format(&self, fmt: defmt::Formatter) {
-        let len = (self.length as usize).min(MAX_PAYLOAD_SIZE);
+        let len = (self.length as usize).min(DATA_POINT_MAX_PAYLOAD_SIZE);
         defmt::write!(
             fmt,
             "Code: {}, Length: {}, Data: {:x}",
@@ -417,7 +425,7 @@ impl From<ResponseCode> for DataPoint {
 }
 
 /// Data point response code
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[repr(u8)]
 /// Response codes that the device can send to the Tindeq app
 // Source: Tindeq API documentation and https://github.com/blims/Tindeq-Progressor-API/blob/78a0bd244303589d0c773ee15ede53e0299712ee/progressor_client.py#L36-L40
@@ -425,7 +433,7 @@ pub enum ResponseCode {
     /// Response to battery voltage sampling command
     SampleBatteryVoltage(u32),
     /// Each measurement is sent together with a timestamp where the timestamp is the number of microseconds since the measurement was started
-    WeightMeasurement(f32, u32),
+    WeightMeasurement(WeightMeasurementBatch),
     /// Calibration factor response
     CalibrationFactor(f32),
     /// Calibration point response (raw value, weight)
@@ -450,13 +458,8 @@ impl Format for ResponseCode {
             ResponseCode::SampleBatteryVoltage(voltage) => {
                 defmt::write!(fmt, "SampleBatteryVoltage: {}", voltage)
             }
-            ResponseCode::WeightMeasurement(weight, timestamp) => {
-                defmt::write!(
-                    fmt,
-                    "WeightMeasurement: Weight: {}, Timestamp: {}",
-                    weight,
-                    timestamp
-                )
+            ResponseCode::WeightMeasurement(measurements) => {
+                defmt::write!(fmt, "WeightMeasurement: {} points", measurements.len())
             }
             ResponseCode::CalibrationFactor(factor) => {
                 defmt::write!(fmt, "CalibrationFactor: {}", factor)
@@ -493,11 +496,15 @@ impl ResponseCode {
     fn length(&self) -> u8 {
         match self {
             ResponseCode::SampleBatteryVoltage(..) => 4,
-            ResponseCode::WeightMeasurement(..) => 8,
+            ResponseCode::WeightMeasurement(measurements) => {
+                (measurements.len() * WEIGHT_MEASUREMENT_SIZE) as u8
+            }
             ResponseCode::CalibrationFactor(..) => 4,
             ResponseCode::CalibrationPoint(..) => 8,
             ResponseCode::LowPowerWarning => 0,
-            ResponseCode::AppVersion(version) => version.len().min(MAX_PAYLOAD_SIZE) as u8,
+            ResponseCode::AppVersion(version) => {
+                version.len().min(DATA_POINT_MAX_PAYLOAD_SIZE) as u8
+            }
             ResponseCode::ProgressorId(..) => DEVICE_ID_SIZE as u8,
             ResponseCode::RfdPeak => 0,
             ResponseCode::RfdPeakSeries => 0,
@@ -505,15 +512,19 @@ impl ResponseCode {
     }
 
     /// Get the value bytes for this response
-    fn value(&self) -> [u8; MAX_PAYLOAD_SIZE] {
-        let mut value = [0; MAX_PAYLOAD_SIZE];
+    fn value(&self) -> [u8; DATA_POINT_MAX_PAYLOAD_SIZE] {
+        let mut value = [0; DATA_POINT_MAX_PAYLOAD_SIZE];
         match self {
             ResponseCode::SampleBatteryVoltage(voltage) => {
                 value[0..4].copy_from_slice(&voltage.to_le_bytes());
             }
-            ResponseCode::WeightMeasurement(weight, timestamp) => {
-                value[0..4].copy_from_slice(&weight.to_le_bytes());
-                value[4..8].copy_from_slice(&timestamp.to_le_bytes());
+            ResponseCode::WeightMeasurement(measurements) => {
+                for (i, (weight, timestamp)) in measurements.iter().enumerate() {
+                    let offset = i * WEIGHT_MEASUREMENT_SIZE;
+                    value[offset..offset + 4].copy_from_slice(&weight.to_le_bytes());
+                    value[offset + 4..offset + WEIGHT_MEASUREMENT_SIZE]
+                        .copy_from_slice(&timestamp.to_le_bytes());
+                }
             }
             ResponseCode::CalibrationFactor(factor) => {
                 value[0..4].copy_from_slice(&factor.to_le_bytes());
@@ -530,7 +541,7 @@ impl ResponseCode {
                 value[..DEVICE_ID_SIZE].copy_from_slice(&reversed);
             }
             ResponseCode::AppVersion(version) => {
-                let len = version.len().min(MAX_PAYLOAD_SIZE);
+                let len = version.len().min(DATA_POINT_MAX_PAYLOAD_SIZE);
                 value[0..len].copy_from_slice(&version[0..len]);
             }
             ResponseCode::RfdPeak => {

--- a/src/progressor.rs
+++ b/src/progressor.rs
@@ -181,7 +181,7 @@ impl DeviceState {
 
     /// Get elapsed inactivity time in milliseconds.
     pub fn get_inactivity_elapsed_ms(&self) -> u32 {
-        Self::now_ms().saturating_sub(self.last_activity_time_ms)
+        Self::now_ms().wrapping_sub(self.last_activity_time_ms)
     }
 
     /// Request deep sleep. The measurement task will power down peripherals first.


### PR DESCRIPTION
- Updated ESP/Embassy/BLE dependencies, including esp-hal 1.1.                                                                                                                                                                                                          
- Added a `cargo flash` alias for easier device flashing.                                                                                                                                                                                                                 
- Improved BLE reliability with higher TX power and requested connection parameters.                                                                                                                                                                                    
- Batched weight measurements into BLE packets to reduce notification overhead.                                                                                                                                                                                         
- Added idle/shutdown deep sleep flow, including HX711 power-down before sleep.                                                                                                                                                                                         
- Switched idle timeout tracking to general device activity instead of BLE disconnect time only.                                                                                                                                                                        
- Updated default HX711 calibration factor from `0.0639` to `0.08`. 